### PR TITLE
Add rubocop and bundler-audit rake tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source 'https://rubygems.org'
 
+gem 'bundler-audit', require: false
 gem 'capybara'
 gem 'parallel_tests'
 gem 'phantomjs-helper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,9 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
+    bundler-audit (0.7.0.1)
+      bundler (>= 1.2.0, < 3)
+      thor (>= 0.18, < 2)
     capybara (3.33.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -79,6 +82,7 @@ GEM
       capybara (~> 3.3)
       site_prism-all_there (>= 0.3.1, < 1.0)
     site_prism-all_there (0.3.2)
+    thor (1.0.1)
     unicode-display_width (1.7.0)
     webdrivers (4.4.1)
       nokogiri (~> 1.6)
@@ -94,6 +98,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bundler-audit
   capybara
   parallel_tests
   phantomjs-helper

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,21 @@
 # frozen_string_literal: true
 
+require 'bundler/audit/task'
 require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 
+# Add Gem Tasks
+Bundler::Audit::Task.new
+RuboCop::RakeTask.new
+
+# Custom Tasks
+desc 'Run rubocop and bundler-audit'
+task :checks do
+  Rake::Task['rubocop'].invoke
+  Rake::Task['bundle:audit'].invoke
+end
+
+# DEFAULT: Run specs in parallel
 desc 'run specs in parallel unless safari'
 task :spec do
   if ENV['SPEC_BROWSER'] == 'safari'

--- a/docker-compose.checks.yml
+++ b/docker-compose.checks.yml
@@ -1,0 +1,8 @@
+version: '2.1'
+services:
+  browsertests_checks:
+    build: .
+    container_name: sample-login-capybara-rspec-tests
+    volumes:
+      - .:/app
+    command: bundle exec rake checks


### PR DESCRIPTION

This change adds...
 - `rubocop` rake task
 - `bundler-audit` rake task
 -  custom `checks` rake task that runs both `rubocop` and `bundler-audit` tasks 
 - adds a docker-compose file (docker-compose.checks.yml) for running the `checks` rake task in the container

To run the `checks` test in a container...
```
$ docker-compose -f docker-compose.checks.yml up
```