### PR TITLE
Docker Refactoring

### DIFF
--- a/.github/workflows/ruby_lint_cve.yml
+++ b/.github/workflows/ruby_lint_cve.yml
@@ -20,7 +20,7 @@ jobs:
         run: docker-compose --version
 
       - name: pull
-        run: docker-compose -f docker-compose.checks.yml pull
+        run: docker-compose -f docker-compose.yml -f docker-compose.checks.yml pull
 
       - name: Run Checks
-        run: docker-compose -f docker-compose.checks.yml up
+        run: docker-compose -f docker-compose.yml -f docker-compose.checks.yml up

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -19,10 +19,10 @@ jobs:
         run: docker-compose --version
 
       - name: docker-compose pull
-        run: docker-compose pull
+        run: docker-compose -f docker-compose.yml -f docker-compose.seleniumchrome.yml pull
 
       - name: Run Selenium Chrome
-        run: docker-compose run -d seleniumchrome
+        run: docker-compose -f docker-compose.yml -f docker-compose.seleniumchrome.yml run -d seleniumchrome
 
       - name: Run Tests
-        run: docker-compose run browsertests
+        run: docker-compose -f docker-compose.yml -f docker-compose.seleniumchrome.yml run browsertests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,43 @@
 # sample-login-capybara-rspec
-FROM ruby:2.6.6-alpine
-
+### Builder Stage ###
+FROM ruby:2.6.6-alpine AS builder
 # Alpine needs build-base for building native extensions
 RUN apk --update add --virtual build-dependencies build-base
 
 # Use the same version of Bundler in the Gemfile.lock
 RUN gem install bundler -v 2.1.4
-
-# Throw errors if Gemfile has been modified since Gemfile.lock
-RUN bundle config --global frozen 1
-
 WORKDIR /app
-
 # Install the Ruby dependencies (defined in the Gemfile/Gemfile.lock)
 COPY Gemfile Gemfile.lock ./
 RUN bundle install
 
-# Clean up build/bundle dependencies
-RUN apk del build-dependencies
-RUN rm -rf /var/lib/apt/lists/*
+### Lint Stage ###
+FROM builder AS lint
+COPY . .
+RUN bundle exec rake rubocop
 
-# Populate the Docker Working Directory with this project's source code
+### Security Static Scan Stage ###
+# Keep build dependencies
+FROM builder AS secscan
+# Add git for bundler-audit
+RUN apk add --no-cache git
+# Just need Rakefile and Gemfile.lock
+COPY Rakefile ./
+RUN bundle exec rake bundle:audit
+
+### Deploy Stage ###
+FROM ruby:2.6.6-alpine AS deploy
+# Throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
+# Run as deployer USER instead of as root
+RUN adduser -D deployer
+USER deployer
+
+# Copy over the built gems directory from builder image
+COPY --from=builder --chown=deployer /usr/local/bundle/ /usr/local/bundle/
+# Copy in app source
+WORKDIR /app
 COPY . .
 
 # To Run the tests - altho this is orchestrated by the docker-compose.yml file

--- a/README.md
+++ b/README.md
@@ -35,8 +35,12 @@ You must have docker installed and running on your local machine.
 
 ### To Run Fully in Docker
 1. Ensure Docker is running
-2. Run the project docker-compose.yml file:  
-`docker-compose up`
+2. Run the project docker-compose.yml file with the
+   docker-compose.seleniumchrome.yml file (this runs using the Chrome
+   standalone container)
+```
+docker-compose -f docker-compose.yml -f docker-compose.seleniumchrome.yml up
+```
 
 
 ## To Run the Automated Tests Locally

--- a/docker-compose.checks.yml
+++ b/docker-compose.checks.yml
@@ -1,8 +1,8 @@
-version: '2.1'
+version: '3.4'
 services:
-  browsertests_checks:
-    build: .
-    container_name: sample-login-capybara-rspec-tests
-    volumes:
-      - .:/app
+  browsertests:
+    build:
+      context: .
+      target: secscan
+    container_name: sample-login-capybara-rspec-secscan
     command: bundle exec rake checks

--- a/docker-compose.seleniumchrome.yml
+++ b/docker-compose.seleniumchrome.yml
@@ -1,0 +1,19 @@
+version: '3.4'
+services:
+  browsertests:
+    environment:
+      - SPEC_BROWSER=seleniumchrome
+    command: ./script/runtests
+    depends_on:
+      - seleniumchrome
+
+  seleniumchrome:
+    image: selenium/standalone-chrome:latest
+    container_name: selenium-chrome
+    volumes:
+      - /dev/shm:/dev/shm
+    healthcheck:
+      test: ["CMD-SHELL", "curl --silent --fail -X HEAD http://localhost:4444/wd/hub"]
+      interval: 2s
+      timeout: 5s
+      retries: 30

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,7 @@
-version: '2.1'
+version: '3.4'
 services:
   browsertests:
     build: .
-    container_name: sample-login-capybara-rspec-tests
+    container_name: sample-login-capybara-rspec
     volumes:
       - .:/app
-    environment:
-      - SPEC_BROWSER=seleniumchrome
-    command: bundle exec rspec
-    depends_on:
-      seleniumchrome:
-        condition: service_healthy
-
-  seleniumchrome:
-    image: selenium/standalone-chrome
-    container_name: selenium-chrome
-    volumes:
-      - /dev/shm:/dev/shm
-    healthcheck:
-      test: ["CMD-SHELL", "curl --silent --fail -X HEAD http://localhost:4444/wd/hub"]
-      interval: 2s
-      timeout: 5s
-      retries: 30

--- a/script/runtests
+++ b/script/runtests
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+COUNTER=0
+REMOTE_BROWSER="http://${SPEC_BROWSER}:4444/wd/hub/status"
+echo "Waiting for ${REMOTE_BROWSER} to become available"
+until wget --spider -q "${REMOTE_BROWSER}" &>/dev/null; do
+  printf "."
+  sleep 1
+  COUNTER=$((COUNTER + 1))
+  if [ $COUNTER -eq 30 ] ; then
+    echo "✘"
+    exit 1
+  fi
+done
+
+echo "✔"
+
+# Run the tests (with any passed in args)
+bundle exec rspec "$@"


### PR DESCRIPTION
Refactor Docker Stuff

- Multistage Dockerfile
    - Smaller deploy image
    - Separate builder stage
    - Separate linter and security static scan stages
    - secscan stage/image that can run bundler-audit (fixes bug where could not git pull ruby-advisory-db in the GH workflows / docker-compose.checks.yml

- Reduced redundancy in docker-compose files tho it increases command line length