### PR TITLE
Add Docker-Based Dev Environment...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,23 @@ WORKDIR /app
 COPY Gemfile Gemfile.lock ./
 RUN bundle install
 
+### Dev Environment ###
+# Before any checks stages so that we can always build a dev env
+# ASSUME source is docker volumed into the image
+FROM builder AS devenv
+# Add git and vim at least
+RUN apk add --no-cache git
+RUN apk add --no-cache vim
+# Start devenv in (command line) shell
+CMD /bin/ash
+
 ### Lint Stage ###
 FROM builder AS lint
 COPY . .
 RUN bundle exec rake rubocop
 
 ### Security Static Scan Stage ###
+# Explicit dependencies (altho redundant with devenv)
 # Keep build dependencies
 FROM builder AS secscan
 # Add git for bundler-audit

--- a/README.md
+++ b/README.md
@@ -138,6 +138,35 @@ installed automatically with the gems)
 2. Install gems (from project root):  
 `bundle`
 
+## Development
+This project can be developed locally or using the supplied basic,
+container-based development environment which includes `vim` and `git`.
+
+### To Develop Using the Container-based Development Environment
+To develop using the supplied container-based development environment...
+1. Build the development environment image specifying the `devenv` build
+   stage as the target and supplying a name (tag) for the image.
+```
+docker build --no-cache --target devenv -t browsertests-dev .
+```
+2. Run the built development environment image either on its own or
+in the docker-compose environment with either the Selenium Chrome
+or Firefox container.  By default the development environment container
+executes the `/bin/ash` shell providing a command line interface. When
+running the development environment container, you must specify the path
+to this project's source code.
+
+To run the development environment on its own, use `docker run`...
+```
+docker run -it --rm -v $(pwd):/app browsertests-dev
+```
+
+To run the development environment in the docker-compose environment,
+use the `docker-compose.dev.yml` file...
+```
+IMAGE=browsertests-dev SRC=${PWD} docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.seleniumchrome.yml run browsertests /bin/ash
+```
+
 
 ## Additional Information
 These tests use the... 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,7 @@
+version: '3.4'
+services:
+  browsertests:
+    image: "${IMAGE}"
+    container_name: "sample-login-capybara-rspec-${IMAGE}"
+    volumes:
+      - ${SRC}:/app


### PR DESCRIPTION
Adding Dev Environment in Docker
 - Separate `devenv` stage in `Dockerfile` with`vim` and `git` before any checks stages
 - Add-on `docker-compose.dev.yml` file that uses specifiable ENV `IMAGE` instead of build and `SRC` path for project source code