### PR TITLE
Add firefox docker-compose support

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -7,7 +7,27 @@ on:
     branches: [ master ]
 
 jobs:
-  default-chrome:
+  default-firefox:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: docker version
+        run: docker --version
+
+      - name: docker-compose version
+        run: docker-compose --version
+
+      - name: pull
+        run: docker-compose -f docker-compose.yml -f docker-compose.seleniumfirefox.yml pull
+
+      - name: Run Selenium Firefox
+        run: docker-compose -f docker-compose.yml -f docker-compose.seleniumfirefox.yml run -d seleniumfirefox
+
+      - name: Run Tests
+        run: docker-compose -f docker-compose.yml -f docker-compose.seleniumfirefox.yml run browsertests
+
+  chrome:
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ You must have docker installed and running on your local machine.
 docker-compose -f docker-compose.yml -f docker-compose.seleniumchrome.yml up
 ```
 
+#### To Run Using the Firefox Standalone Container
+2. Run the project docker-compose.yml file (this runs using the Firefox
+   standalone container
+```
+docker-compose -f docker-compose.yml -f docker-compose.seleniumfirefox.yml up
+```
 
 ## To Run the Automated Tests Locally
 The tests in this project can be run locally either with...

--- a/docker-compose.seleniumfirefox.yml
+++ b/docker-compose.seleniumfirefox.yml
@@ -1,0 +1,20 @@
+version: '3.4'
+services:
+  browsertests:
+    environment:
+      - BROWSER=firefox
+      - REMOTE=http://seleniumfirefox:4444/wd/hub
+    command: ./script/runtests
+    depends_on:
+      - seleniumfirefox
+
+  seleniumfirefox:
+    image: selenium/standalone-firefox:latest
+    container_name: selenium-firefox
+    volumes:
+      - /dev/shm:/dev/shm
+    healthcheck:
+      test: ["CMD-SHELL", "curl --silent --fail -X HEAD http://localhost:4444/wd/hub"]
+      interval: 2s
+      timeout: 5s
+      retries: 30


### PR DESCRIPTION
Added docker-compose support for Selenium Firefox Container

With the browser handling refactored, it made it easy to add on a `docker-compose.seleniumfirefox.yml` file. 
Also...
- Updated readme
- Made the firefox docker-compose the default `runtest` GitHub Action