### PR TITLE
Updated just gems same bundler in docker-compose dev env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM ruby-alpine AS builder
 RUN apk --update add --virtual build-dependencies build-base
 
 # Use the same version of Bundler in the Gemfile.lock
-RUN gem install bundler -v 2.1.4
+RUN gem install bundler -v 2.2.25
 WORKDIR /app
 # Install the Ruby dependencies (defined in the Gemfile/Gemfile.lock)
 COPY Gemfile Gemfile.lock ./

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,9 +4,9 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
-    bundler-audit (0.7.0.1)
+    bundler-audit (0.8.0)
       bundler (>= 1.2.0, < 3)
-      thor (>= 0.18, < 2)
+      thor (~> 1.0)
     capybara (3.35.3)
       addressable
       mini_mime (>= 0.1.3)
@@ -18,18 +18,16 @@ GEM
     childprocess (3.0.0)
     cliver (0.3.2)
     diff-lcs (1.4.4)
-    ffi (1.14.2)
-    ffi-libarchive (1.0.4)
+    ffi (1.15.3)
+    ffi-libarchive (1.0.17)
       ffi (~> 1.0)
-    mini_mime (1.0.2)
-    mini_portile2 (2.5.1)
-    nokogiri (1.11.4)
-      mini_portile2 (~> 2.5.0)
+    mini_mime (1.1.0)
+    nokogiri (1.12.3-x86_64-linux)
       racc (~> 1.4)
     parallel (1.20.1)
-    parallel_tests (3.4.0)
+    parallel_tests (3.7.0)
       parallel
-    parser (3.0.0.0)
+    parser (3.0.2.0)
       ast (~> 2.4.1)
     phantomjs-helper (1.1.0)
       ffi-libarchive
@@ -45,8 +43,8 @@ GEM
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rainbow (3.0.0)
-    rake (13.0.3)
-    regexp_parser (2.0.3)
+    rake (13.0.6)
+    regexp_parser (2.1.1)
     rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -63,41 +61,41 @@ GEM
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
     rspec-support (3.10.2)
-    rubocop (1.9.1)
+    rubocop (1.19.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 1.2.0, < 2.0)
+      rubocop-ast (>= 1.9.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.4.1)
-      parser (>= 2.7.1.5)
+    rubocop-ast (1.9.1)
+      parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
-    rubyzip (2.3.0)
+    rubyzip (2.3.2)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    site_prism (3.7)
+    site_prism (3.7.1)
       addressable (~> 2.5)
       capybara (~> 3.8)
       site_prism-all_there (>= 0.3.1, < 1.0)
     site_prism-all_there (0.3.2)
     thor (1.1.0)
     unicode-display_width (2.0.0)
-    webdrivers (4.5.0)
+    webdrivers (4.6.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (>= 3.0, < 4.0)
-    websocket-driver (0.7.3)
+    websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
   bundler-audit
@@ -114,4 +112,4 @@ DEPENDENCIES
   webdrivers
 
 BUNDLED WITH
-   2.1.4
+   2.2.25


### PR DESCRIPTION
# Update bundler and gems in Docker-based environment

This change set updates the bundler version from 2.1.4 to 2.2.25 and updates the gems.

## Caveats
By updating bundler to this version, this project is now platform-specific specifically for nokogiri.

The impact of this is that the linux-based Docker environment requires a different `Gemfile.lock`
than say a macOS `Gemfile.lock`.  Given the advantages of containerization, this project will now
prefer the Docker environment over a local environment.  This also ensure that the GitHub Actions
checks will pass.

Going forward, it is recommended that any development use the Docker-based dev environment/layer.

To run and or develop locally, one should run the `bundle install` and verify that the Gemfile.lock
is modified for the local environment.  **This local-only `Gemfile.lock` should not be committed.**

## Testing
This change set was tested locally on macOS as well as using the docker-compose environment.