### PR TITLE
Improve docker-compose Framework

### DIFF
--- a/.github/workflows/check_deployable.yml
+++ b/.github/workflows/check_deployable.yml
@@ -47,80 +47,35 @@ jobs:
       - name: Build app deploy
         run: docker build --no-cache -t app .
 
-  runtests-default-chrome:
+  run-tests-default-chrome:
     needs: build-deploy
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v1
-      - name: docker version
-        run: docker --version
+      - name: dockercomposerun (Run tests) with defaults
+        run: ./script/dockercomposerun
 
-      - name: docker-compose version
-        run: docker-compose --version
-
-      - name: docker-compose config
-        run: docker-compose -f docker-compose.yml -f docker-compose.selenium.yml config
-
-      - name: docker-compose pull
-        run: docker-compose -f docker-compose.yml -f docker-compose.selenium.yml pull
-
-      - name: Run Selenium Chrome
-        run: docker-compose -f docker-compose.yml -f docker-compose.selenium.yml run -d seleniumbrowser
-
-      - name: Run Tests
-        run: docker-compose -f docker-compose.yml -f docker-compose.selenium.yml run browsertests
-
-  runtests-firefox:
+  run-tests-specified-firefox:
     needs: build-deploy
     runs-on: ubuntu-latest
     env:
       BROWSER: firefox
-      SELENIUM_IMAGE: selenium/standalone-firefox
+      SELENIUM_IMAGE: selenium/standalone-firefox:latest
 
     steps:
       - uses: actions/checkout@v1
-      - name: docker version
-        run: docker --version
+      - name: dockercomposerun (Run tests) with Firefox
+        run: ./script/dockercomposerun
 
-      - name: docker-compose version
-        run: docker-compose --version
-
-      - name: docker-compose config
-        run: docker-compose -f docker-compose.yml -f docker-compose.selenium.yml config
-
-      - name: pull
-        run: docker-compose -f docker-compose.yml -f docker-compose.selenium.yml pull
-
-      - name: Run Selenium Firefox
-        run: docker-compose -f docker-compose.yml -f docker-compose.selenium.yml run -d seleniumbrowser
-
-      - name: Run Tests
-        run: docker-compose -f docker-compose.yml -f docker-compose.selenium.yml run browsertests
-
-  runtests-edge:
+  run-tests-specified-edge:
     needs: build-deploy
     runs-on: ubuntu-latest
     env:
       BROWSER: edge
-      SELENIUM_IMAGE: selenium/standalone-edge
+      SELENIUM_IMAGE: selenium/standalone-edge:latest
 
     steps:
       - uses: actions/checkout@v1
-      - name: docker version
-        run: docker --version
-
-      - name: docker-compose version
-        run: docker-compose --version
-
-      - name: docker-compose config
-        run: docker-compose -f docker-compose.yml -f docker-compose.selenium.yml config
-
-      - name: pull
-        run: docker-compose -f docker-compose.yml -f docker-compose.selenium.yml pull
-
-      - name: Run Selenium Edge
-        run: docker-compose -f docker-compose.yml -f docker-compose.selenium.yml run -d seleniumbrowser
-
-      - name: Run Tests
-        run: docker-compose -f docker-compose.yml -f docker-compose.selenium.yml run browsertests
+      - name: dockercomposerun (Run tests) with Edge
+        run: ./script/dockercomposerun

--- a/.github/workflows/check_development_environment.yml
+++ b/.github/workflows/check_development_environment.yml
@@ -10,7 +10,7 @@ env:
   # Use Docker Buildkit for builds
   DOCKER_BUILDKIT: 1
   DEVENV: devenv
-  IMAGE: app-devenv
+  BROWSERTESTS_IMAGE: app-devenv
 
 jobs:
   build-devenv:
@@ -22,10 +22,10 @@ jobs:
         run: docker --version
 
       - name: Build settings
-        run: "echo DOCKER_BUILDKIT=${DOCKER_BUILDKIT} --target ${DEVENV} -t ${IMAGE}"
+        run: "echo DOCKER_BUILDKIT=${DOCKER_BUILDKIT} --target ${DEVENV} -t ${BROWSERTESTS_IMAGE}"
 
       - name: Build app development environment
-        run: "docker build --no-cache --target ${DEVENV} -t ${IMAGE} ."
+        run: "docker build --no-cache --target ${DEVENV} -t ${BROWSERTESTS_IMAGE} ."
 
       - name: Check no mutation to source
         run: "[ ! -f foobear ]"
@@ -36,7 +36,7 @@ jobs:
       - name: Check source is mutated
         run: "[ -f foobear ]"
 
-  runtests-default-chrome:
+  run-tests-default-chrome:
     needs: build-devenv
     runs-on: ubuntu-latest
 
@@ -46,29 +46,17 @@ jobs:
         run: docker --version
 
       - name: Build app development environment
-        run: "docker build --no-cache --target ${DEVENV} -t ${IMAGE} ."
+        run: "docker build --no-cache --target ${DEVENV} -t ${BROWSERTESTS_IMAGE} ."
 
-      - name: docker-compose version
-        run: docker-compose --version
+      - name: dockercomposerun (Run tests) with defaults
+        run: BROWSERTESTS_SRC=${PWD} ./script/dockercomposerun
 
-      - name: docker-compose config
-        run: "SRC=${PWD} docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.selenium.yml config"
-
-      - name: docker-compose pull
-        run: "SRC=${PWD} docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.selenium.yml pull"
-
-      - name: Run Selenium Chrome
-        run: "SRC=${PWD} docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.selenium.yml run -d seleniumbrowser"
-
-      - name: Run Tests
-        run: "SRC=${PWD} docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.selenium.yml run browsertests"
-
-  runtests-firefox:
+  runtests-specified-firefox:
     needs: build-devenv
     runs-on: ubuntu-latest
     env:
       BROWSER: firefox
-      SELENIUM_IMAGE: selenium/standalone-firefox
+      SELENIUM_IMAGE: selenium/standalone-firefox:latest
 
     steps:
       - uses: actions/checkout@v1
@@ -76,29 +64,17 @@ jobs:
         run: docker --version
 
       - name: Build app development environment
-        run: "docker build --no-cache --target ${DEVENV} -t ${IMAGE} ."
+        run: "docker build --no-cache --target ${DEVENV} -t ${BROWSERTESTS_IMAGE} ."
 
-      - name: docker-compose version
-        run: docker-compose --version
+      - name: dockercomposerun (Run tests) with Firefox
+        run: BROWSERTESTS_SRC=${PWD} ./script/dockercomposerun
 
-      - name: docker-compose config
-        run: "SRC=${PWD} docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.selenium.yml config"
-
-      - name: pull
-        run: "SRC=${PWD} docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.selenium.yml pull"
-
-      - name: Run Selenium Firefox
-        run: "SRC=${PWD} docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.selenium.yml run -d seleniumbrowser"
-
-      - name: Run Tests
-        run: "SRC=${PWD} docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.selenium.yml run browsertests"
-
-  runtests-edge:
+  run-tests-specified-edge:
     needs: build-devenv
     runs-on: ubuntu-latest
     env:
       BROWSER: edge
-      SELENIUM_IMAGE: selenium/standalone-edge
+      SELENIUM_IMAGE: selenium/standalone-edge:latest
 
     steps:
       - uses: actions/checkout@v1
@@ -106,19 +82,7 @@ jobs:
         run: docker --version
 
       - name: Build app development environment
-        run: "docker build --no-cache --target ${DEVENV} -t ${IMAGE} ."
+        run: "docker build --no-cache --target ${DEVENV} -t ${BROWSERTESTS_IMAGE} ."
 
-      - name: docker-compose version
-        run: docker-compose --version
-
-      - name: docker-compose config
-        run: "SRC=${PWD} docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.selenium.yml config"
-
-      - name: pull
-        run: "SRC=${PWD} docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.selenium.yml pull"
-
-      - name: Run Selenium Edge
-        run: "SRC=${PWD} docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.selenium.yml run -d seleniumbrowser"
-
-      - name: Run Tests
-        run: "SRC=${PWD} docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.selenium.yml run browsertests"
+      - name: dockercomposerun (Run tests) with Edge
+        run: BROWSERTESTS_SRC=${PWD} ./script/dockercomposerun

--- a/README.md
+++ b/README.md
@@ -1,100 +1,139 @@
 # sample-login-capybara-rspec
 
 ## Overview
-This is an example 
-[Capybara](https://github.com/teamcapybara/capybara) [RSpec](http://rspec.info/) [Ruby](https://www.ruby-lang.org)
-implementation of Acceptance Test Driven Development (ATDD).
-**However, it also provides a somewhat extensible framework that can be reused
-by replacing the existing tests.**
+This is an example of Acceptance Test Driven Development (ATDD) using
+[Capybara](https://github.com/teamcapybara/capybara),
+[RSpec](http://rspec.info/), [Ruby](https://www.ruby-lang.org).
+
+**However, it also provides a somewhat extensible framework that
+can be reused by replacing the existing tests.**
 
 These tests show how to use Capybara-RSpec to verify...
-* That critical elements are on a page
 * The ability to login as a user
+* That critical elements are on a page
 
-It also demonstrates the basic features
-of the Capybara-RSpec framework and how they can be extended.
+It also demonstrates the basic features of the
+Capybara-RSpec framework and how they can be extended.
 
-### Run Locally or in Containers
-This project can be run locally or fully in containers using Docker.
+## Run Locally or in Containers
+This project can be run...
+* Locally containerized in 2 separate Docker containers:
+  one containing the tests, the other the browser
+* Locally natively running the tests against a local browser
+  or a containerized browser
 
-### Contents of this Framework
+## Contents of this Framework
 This framework contains support for...
-* Local or fully containerized execution
-* Using Selenium Standalone containers eliminating the need for locally installed browsers or drivers
+* Using Selenium Standalone containers eliminating the need
+  for locally installed browsers or drivers
 * Multiple local browsers with automatic driver management
-
+* Single-command docker-compose framework to run
+  the tests or a supplied command
+* Native through fully-containerized execution
+* Containerized development environment
+* Continuous Integration with GitHub Actions vetting
+  linting, static security scanning, and functional
+  tests
 
 ## To Run the Automated Tests in Docker
-The tests in this project can be run be run fully in Docker
-assuming that Docker is installed and running.  This will build
-a docker image of this project and execute the tests against
-a Selenium Standalone container.
+The easiest way to run the tests is with the docker-compose
+framework using the `dockercomposerun` script.
+
+This will build a docker image of this project and run
+the tests against a
+[Selenium Standalone](https://github.com/SeleniumHQ/docker-selenium)
+container.
+
+You can view the running tests, using the included
+Virtual Network Computing (VNC) server.
 
 ### Prerequisites
-You must have docker installed and running on your local machine.
+You must have Docker installed and running on your local machine.
 
-### To Run Fully in Docker
+### To See the Tests Run Using the VNC Server
+> Browsers in the containers are not visible in the VNC server
+  when running `headless`.
+
+The Selenium Standalone containers used in the docker-compose
+framework have an included VNC server for viewing and
+debugging the tests.
+
+You can use either a VNC client or a web browser to view the tests.
+
+1. Ensure that you are running the Selenium Standalone containers
+   (e.g. in the docker-compose framework)
+2. To view the tests... using a web browser, navigate to
+   http://localhost:7900/; or to use a VNC server, use
+   `vnc://localhost:5900` (On Mac you can simply enter
+   this address into a web browser)
+3. When prompted for the (default) password, enter `secret`
+
+For more information, see the Selenium Standalone Image
+[VNC documentation](https://github.com/SeleniumHQ/docker-selenium#debugging)
+
+### To Run Using the Default Chrome Standalone Container
 1. Ensure Docker is running
-2. Run the project docker-compose.yml file with the
-   docker-compose.selenium.yml file (this runs using the Chrome
-   standalone container)
-```
-docker-compose -f docker-compose.yml -f docker-compose.selenium.yml up
-```
+2. From the project root directory, run the `dockercomposerun`
+   script with the defaults...
 
-#### To Run Using the Firefox Standalone Container
+   ```
+   ./script/dockercomposerun
+   ```
+
+### To Run Using the Firefox Standalone Container
 1. Ensure Docker is running
-2. Run the project docker-compose.yml file (this runs using the Firefox
-   standalone container
-```
-BROWSER=firefox SELENIUM_IMAGE=selenium/standalone-firefox docker-compose -f docker-compose.yml -f docker-compose.selenium.yml up
-```
+2. From the project root directory, run the `dockercomposerun`
+   script setting the `BROWSER` and `SELENIUM_IMAGE`
+   environment variables to specify Firefox...
+   ```
+   BROWSER=firefox SELENIUM_IMAGE=selenium/standalone-firefox ./script/dockercomposerun
+   ```
 
-#### To Run Using the Edge Standalone Container
+### To Run Using the Edge Standalone Container
 1. Ensure Docker is running
-2. Run the project docker-compose.yml file (this runs using the Edge
-   standalone container
-```
-BROWSER=edge SELENIUM_IMAGE=selenium/standalone-edge docker-compose -f docker-compose.yml -f docker-compose.selenium.yml up
-```
+2. From the project root directory, run the `dockercomposerun`
+   script setting the `BROWSER` and `SELENIUM_IMAGE`
+   environment variables to specify Edge...
+   ```
+   BROWSER=edge SELENIUM_IMAGE=selenium/standalone-edge ./script/dockercomposerun
+   ```
 
-## To Run the Automated Tests Locally
-The tests in this project can be run locally either with...
-* Local browsers (requires the browsers to be installed)
-* Selenium Standalone containers (requires the containers to be running in Docker)
+### To Run the Test Container Interactively (i.e. "Shell In")
+1. Ensure Docker is running
+2. From the project root directory, run the `dockercomposerun`
+   script and supply the shell command `sh`...
+   ```
+   ./script/dockercomposerun sh
+   ```
+3. Run desired commands in the container
+   (e.g. `bundle exec rake`)
+4. Run the exit command to exit the Test container
+   ```
+   exit
+   ```
 
-The tests can be run either directly by the RSpec runner or by the
-supplied Rakefile.
+## To Run the Automated Tests Natively
+Assuming that you have a Ruby development environment,
+the tests either can be run directly by the RSpec
+runner or by the supplied Rakefile.
 
-### To Run Using Rake
-When running the tests using Rake, the tests are run in
-parallel **unless** the Safari browser is chosen.
+### Prerequisites
+* Ruby 2.7.4
+* To run the tests using a specific browser requires that browser
+be installed
+(e.g. to run the tests in the Chrome Browser requires
+Chrome be installed).
 
-To run the automated tests using Rake, execute...  
-*command-line-arguments* `bundle exec rake`
+1. Install bundler (if not already installed for your Ruby):
+   ```
+   $ gem install bundler
+   ```
+2. Install gems (from project root):
+   ```
+   $ bundle install
+   ```
 
-* To run using the default ":selenium" browser (Firefox), execute...  
-`bundle exec rake`
-
-### To Run Using RSpec
-When running the tests using RSpec, the tests are run sequentially.
-
-To run the automated tests using RSpec, execute...  
-*command-line-arguments* `bundle exec rspec`
-
-* To run using the default ":selenium" browser (Firefox), execute...  
-`bundle exec rspec`
-
-### Command Line Arguments
-#### Specify Remote (Container) URL
-`REMOTE=`...
-
-Specifying a Remote URL creates a remote browser of type
-specified by `BROWSER` at the specified remote URL  
-
- **Example:**
-`REMOTE='http://localhost:4444/wd/hub'`
-
+### Environment Variables
 #### Specify Browser
 `BROWSER=`...
 
@@ -102,102 +141,99 @@ specified by `BROWSER` at the specified remote URL
 `BROWSER=chrome`
 
 Currently the following browsers are supported in this project:
-* `chrome` - Google Chrome (requires Chrome and installs chromedriver)
-* `chrome_headless` - Google Chrome run in headless mode (requires Chrome > 59 and installs chromedriver)
-* `edge` - Microsoft Edge (requires Edge)
-* `firefox` - Mozilla Firefox (requires Firefox and installs geckodriver)
-* `firefox_headless` - Mozilla Firefox run in headless mode (requires Firefox and installs geckodriver)
-* `phantomjs` - PhantomJS headless browser (installs PhantomJS)
-* `safari` - Apple Safari (requires Safari)
+* `chrome` - Google Chrome (requires Chrome and installs chromedriver if local)
+* `chrome_headless` - Google Chrome run in headless mode (requires Chrome > 59 and installs chromedriver if local)
+* `edge` - Microsoft Edge (requires Edge and installs edgedriver if local)
+* `firefox` - Mozilla Firefox (requires Firefox and installs geckodriver if local)
+* `firefox_headless` - Mozilla Firefox run in headless mode (requires Firefox and installs geckodriver if local)
+* `phantomjs` - PhantomJS headless browser (local only, installs PhantomJS)
+* `safari` - Apple Safari (local only, requires Safari)
 
-### To Run Using the Selenium Standalone Debug Containers
-These tests can be run using the Selenium Standalone Debug containers for both
-Chrome and Firefox.  These *debug* containers run a VNC server that allow you to see
-the tests running in the browser in that container.  These Selenium Standalone Debug containers
-must be running on the default port of `4444`.
+> This project uses the
+> [Webdrivers](https://github.com/titusfortner/webdrivers)
+> gem to automatically download and maintain chromedriver, edgedriver, and
+> geckodriver (Firefox).
 
-For more information on these Selenium Standalone Debug containers see https://github.com/SeleniumHQ/docker-selenium.
+#### Specify Remote (Container) URL
+`REMOTE=`...
 
-#### Prerequisites
-You must have docker installed and running on your local machine.
+Specifying a Remote URL creates a remote browser of type
+specified by `BROWSER` at the specified remote URL
 
-To use the VNC server, you must have a VNC client on your local machine (e.g. Screen Sharing application on Mac).
+ **Example:**
+`REMOTE='http://localhost:4444/wd/hub'`
 
-#### To Run Using Selenium Standalone Chrome Debug Container
-1. Ensure Docker is running on your local machine
-2. Run the Selenium Standalone Chrome Debug container on the default ports of 4444 and 5900 
-for the VNC server  
-`docker run -d -p 4444:4444 -p 5900:5900 -v /dev/shm:/dev/shm selenium/standalone-chrome-debug:latest`
-3. Wait for the Selenium Standalone Chrome Debug container to be running (e.g. 'docker ps')
-4. Run the tests specifying the `REMOTE` and `BROWSER=chrome`  
-`REMOTE='http://localhost:4444/wd/hub' BROWSER=chrome bundle exec rspec`
+### Examples of Running the Tests
+#### Defaults
+```
+bundle exec rake
+```
 
-#### To Run Using Selenium Standalone Firefox Debug Container
-1. Ensure Docker is running on your local machine
-2. Run the Selenium Standalone Firefox Debug container on the default ports of 4444 and 5900 
-for the VNC server  
-`docker run -d -p 4444:4444 -p 5900:5900 -v /dev/shm:/dev/shm selenium/standalone-firefox-debug:latest`
-3. Wait for the Selenium Standalone Firefox Debug container to be running (e.g. 'docker ps')
-4. Run the tests specifying the `REMOTE` and `BROWSER=firefox`  
-`REMOTE='http://localhost:4444/wd/hub' BROWSER=firefox bundle exec rspec`
+> When running the tests locally natively using Rake, the tests are run in
+> parallel **unless** the Safari browser is chosen.
 
-#### To See the Tests Run Using the VNC Server
-1. Connect to vnc://localhost:5900 (On Mac you can simply enter this address into a Browser)
-2. When prompted for the (default) password, enter `secret`
+```
+bundle exec rspec
+```
 
+#### Local Browsers
+```
+BROWSER=chrome_headless bundle exec rake
+```
 
-## Requirements and Local Setup
-* Running the tests using Docker or to use Selenium Standalone Containers requires Docker to be installed and running
-* Tests run locally with Ruby 2.7.4
-* To run the tests using a specific **local** browser requires that browser 
-be installed - NOTE: chromedriver, geckodriver, and phantomjs will be
-installed automatically with the gems)
+#### Using the Selenium Standalone Containers
+Like the docker-compose framework, these tests can be run natively
+using the Selenium Standalone containers and the VNC Server
+if you want.
 
-### Setup If Running Locally
-1. Install bundler (if not already installed for your Ruby):  
-`gem install bundler`
-2. Install gems (from project root):  
-`bundle`
+For specifics, see the Selenium Standalone Image
+[documentation](https://github.com/SeleniumHQ/docker-selenium).
+
+1. Run the Selenium Standalone image with standard port and volume mapping...
+   ```
+   docker run -d -p 4444:4444 -p 5900:5900 -p 7900:7900 -v /dev/shm:/dev/shm selenium/standalone-chrome
+   ```
+2. If you want, launch the VNC client in app or browser
+3. Run the tests specifying the remote Selenium container...
+   ```
+   REMOTE='http://localhost:4444/wd/hub' BROWSER=chrome bundle exec rspec
+   ```
 
 ## Development
-Due to bundler moving to platform-specific `bundle install`/`Gemfile.lock`,
-specifically `nokogiri`, **updates to be committed to this project must be made
-within the container-based (Docker) development environment**, especially any
-gem updates.
-
-The supplied basic, container-based development environment includes
-`vim` and `git`.
-
-Running the project locally should be reserved for triage and exploration.
+This project can be developed locally or using the supplied basic,
+container-based development environment which include `vim` and `git`.
 
 ### To Develop Using the Container-based Development Environment
 To develop using the supplied container-based development environment...
 1. Build the development environment image specifying the `devenv` build
    stage as the target and supplying a name (tag) for the image.
-```
-docker build --no-cache --target devenv -t browsertests-dev .
-```
-2. Run the built development environment image either on its own or
-in the docker-compose environment with either the Selenium Chrome
-or Firefox container.  By default the development environment container
-executes the `/bin/ash` shell providing a command line interface. When
-running the development environment container, you must specify the path
-to this project's source code.
+   ```
+   docker build --no-cache --target devenv -t browsertests-dev .
+   ```
+2. Run the development environment image either on its own or
+   in the docker-compose environment with either the Selenium Chrome
+   or Firefox container.  By default the development environment
+   container executes the `/bin/ash` shell providing a command
+   line interface. When running the development environment
+   container, you must specify the path to this project's
+   source code.
 
-To run the development environment on its own, use `docker run`...
+#### Running Just the Test Development Image
+To run the development environment on its own, use
+`docker run`...
 ```
 docker run -it --rm -v $(pwd):/app browsertests-dev
 ```
 
+#### Running the Test Development Image in docker-compose
 To run the development environment in the docker-compose environment,
-use the `docker-compose.dev.yml` file...
+with a Selenium Standalone container use the `dockercomposerun`
+script and run it interactively with the default shell `/bin/ash`...
 ```
-IMAGE=browsertests-dev SRC=${PWD} docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.selenium.yml run browsertests /bin/ash
+BROWSERTESTS_IMAGE=browsertests-dev BROWSERTESTS_SRC=${PWD} ./script/dockercomposerun /bin/ash
 ```
-
-
-## Additional Information
-These tests use the... 
+## Sources and Additional Information
+These tests use the...
 * SitePrism page object gem: [SitePrism docs](http://www.rubydoc.info/gems/site_prism/index),
 [SitePrism on github](https://github.com/natritmeyer/site_prism)
 * Webdrivers browser driver helper gem: [Webdrivers on github](https://github.com/titusfortner/webdrivers)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,6 @@
 version: '3.4'
 services:
   browsertests:
-    image: "${IMAGE}"
-    container_name: "sample-login-capybara-rspec-${IMAGE}"
+    image: "${BROWSERTESTS_IMAGE}"
     volumes:
-      - ${SRC}:/app
+      - ${BROWSERTESTS_SRC}:/app

--- a/docker-compose.selenium.yml
+++ b/docker-compose.selenium.yml
@@ -3,17 +3,21 @@ services:
   browsertests:
     environment:
       - BROWSER=${BROWSER:-chrome}
-      - REMOTE=http://seleniumbrowser:4444/wd/hub
+      - REMOTE=http://${SELENIUM_HOSTNAME:-seleniumbrowser}:4444/wd/hub
+      - REMOTE_STATUS=http://${SELENIUM_HOSTNAME:-seleniumbrowser}:4444/wd/hub/status
     command: ./script/runtests
     depends_on:
       - seleniumbrowser
 
   seleniumbrowser :
     image: ${SELENIUM_IMAGE:-selenium/standalone-chrome:latest}
-    container_name: selenium-${BROWSER:-browser-unspecified}
+    container_name: ${SELENIUM_HOSTNAME:-seleniumbrowser}
     shm_size: 2gb
     volumes:
       - /dev/shm:/dev/shm
+    ports:
+      - "5900:5900"
+      - "7900:7900"
     healthcheck:
       test: ["CMD-SHELL", '/opt/bin/check-grid.sh --host 0.0.0.0 --port 4444']
       interval: 15s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,6 @@ version: '3.4'
 services:
   browsertests:
     build: .
-    container_name: sample-login-capybara-rspec
+    container_name: ${BROWSERTESTS_HOSTNAME:-browsertests}
     volumes:
       - .:/app

--- a/script/dockercomposerun
+++ b/script/dockercomposerun
@@ -1,0 +1,67 @@
+#!/bin/sh
+# This script runs the project docker-compose framework.
+#
+# - The arguments to this script are passed to the browsertests service
+#   as command override
+#
+# - Any environment variables set when calling this script are passed
+#   through to the docker-compose framework
+#   (e.g. configuration other than the defaults
+#
+
+# Exit script on any errors
+set -e
+
+echo ''
+echo "ENVIRONMENT VARIABLES..."
+env
+echo ''
+
+echo 'DOCKER VERSION...'
+docker --version
+docker-compose --version
+echo ''
+
+echo 'DOCKER-COMPOSE COMMAND...'
+docker_compose_command='docker-compose -f docker-compose.yml -f docker-compose.selenium.yml '
+echo "...COMMAND: [${docker_compose_command}]"
+echo ''
+
+echo 'DOCKER-COMPOSE CONFIGURATION...'
+$docker_compose_command config
+echo ''
+
+echo 'DOCKER-COMPOSE PULLING...'
+set +e
+$docker_compose_command pull
+echo '...Allowing pull errors (for local images)'
+set -e
+echo ''
+
+echo 'DOCKER IMAGES...'
+docker images
+echo ''
+
+echo "DOCKER-COMPOSE RUNNING [$@]..."
+# Allow to fail but catch return code
+set +e
+$docker_compose_command run browsertests "$@"
+run_return_code=$?
+# NOTE return code must be caught before any other command
+set -e
+echo ''
+
+if [ $run_return_code -eq 0 ]; then
+    run_disposition='PASSED'
+else
+    run_disposition='FAILED'
+fi
+echo "...RUN [${run_disposition}] WITH RETURN CODE [${run_return_code}]"
+echo ''
+
+echo 'DOCKER-COMPOSE DOWN...'
+$docker_compose_command down
+echo ''
+
+echo "EXITING WITH ${run_disposition} RUN RETURN CODE ${run_return_code}"
+exit $run_return_code

--- a/script/runtests
+++ b/script/runtests
@@ -1,18 +1,25 @@
 #!/bin/sh
+# This script orchestrates running the browser tests
+# with a remote browser if its status point is set
 
-COUNTER=0
-REMOTE_STATUS="${REMOTE}/status"
-echo "Waiting for ${REMOTE_STATUS} to become available"
-until wget --spider -q "${REMOTE_STATUS}" &>/dev/null; do
-  printf "."
-  sleep 1
-  COUNTER=$((COUNTER + 1))
-  if [ $COUNTER -eq 30 ] ; then
-    echo "✘"
-    exit 1
-  fi
-done
-echo "✔"
+# Assumes wget (Alpine)
+
+if [ ! -z "${REMOTE_STATUS}" ];
+then
+  COUNTER=0
+  echo "Waiting for ${REMOTE_STATUS} to become available"
+  until wget --spider -q "${REMOTE_STATUS}" &>/dev/null; do
+    printf "."
+    sleep 1
+    COUNTER=$((COUNTER + 1))
+    if [ $COUNTER -eq 30 ] ; then
+      echo "✘"
+      exit 1
+    fi
+  done
+
+  echo "✔"
+fi
 
 # Run the tests (with any passed in args)
 bundle exec rspec "$@"


### PR DESCRIPTION
# What
This change set improves the docker-compose framework by...
* Updating the `runtests` script to support local runs
* Adding a `dockercomposerun` script to automate setup, running, and tear down
* Adding namespacing and consistency to the framework's environment variables
* Simplifying the GitHub Action checks workflows to use the `dockercomposerun` script
* Updating and editing the README

This change set is based upon prior art of https://github.com/brianjbayer/sample-login-watir-cucumber/pull/36.

# Why
This should make the project easier to use and maintain by adding automation
of the run, making CI and local usage consistent, and reducing tasks and
duplication in the CI. 

# Change Impact Analysis and Testing

- [x] Added `dockercomposerun` vetted in CI
  - [x] Defaults
  - [x] Browser specification (env vars)
- [x] Changed `runtests` script
  - [x] Remote functionality vetted in CI
  - [x]  Local (`REMOTE_STATUS` not set): `REMOTE_STATUS= ./script/runtests`
- [x] Dev environment
  - [x] Functionality vetted in CI
  - [x] Documented building and running interactively
- [ ] README
  - [x] Run defaults: `./script/dockercomposerun`
  - [x] Run Firefox: `BROWSER=firefox SELENIUM_IMAGE=selenium/standalone-firefox ./script/dockercomposerun`
  - [x] Run Edge:  `BROWSER=edge SELENIUM_IMAGE=selenium/standalone-edge ./script/dockercomposerun`
  - [x] Run Interactively: ./script/dockercomposerun sh
  - [ ] Development environment:
    - [x] Build: `docker build --no-cache --target devenv -t browsertests-dev .`
    - [x] Run docker: `docker run -it --rm -v $(pwd):/app browsertests-dev`
    - [x] Run docker-compose: `BROWSERTESTS_IMAGE=browsertests-dev BROWSERTESTS_SRC=${PWD} ./script/dockercomposerun /bin/ash`
    - [x] `docker run -d -p 4444:4444 -p 5900:5900 -p 7900:7900 -v /dev/shm:/dev/shm selenium/standalone-chrome`
    - [x] `REMOTE='http://localhost:4444/wd/hub' BROWSER=chrome bundle exec rspec`
  - [x] VNC client app: `vnc://localhost:5900`
  - [x] VNC web browser: http://localhost:7900/
- [x] Changed docker-compose environment variables: `SELENIUM_HOSTNAME=foo BROWSERTESTS_HOSTNAME=bar ./script/dockercomposerun` 
  - [x] `SELENIUM_HOSTNAME`
  - [x] `BROWSERTESTS_HOSTNAME`