### PR TITLE
Fix dockercomposerun for Development Environment

### DIFF
--- a/script/dockercomposerun
+++ b/script/dockercomposerun
@@ -24,6 +24,10 @@ echo ''
 
 echo 'DOCKER-COMPOSE COMMAND...'
 docker_compose_command='docker-compose -f docker-compose.yml -f docker-compose.selenium.yml '
+if [ ! -z ${BROWSERTESTS_IMAGE} ]; then
+  echo "...Using Development Environment with Image [${BROWSERTESTS_IMAGE}]"
+  docker_compose_command="${docker_compose_command} -f docker-compose.dev.yml "
+fi
 echo "...COMMAND: [${docker_compose_command}]"
 echo ''
 


### PR DESCRIPTION
# What
Fixes the `dockercomposerun` script to have the logic to support the development environment.

# Why
Without the missing logic, the `docker-compose.dev.yml` file was not being added causing the deploy image to be (built and) used.

# Change Impact Analysis and Testing
Verified via `dockercomposerun` output that the `docker-compose.dev.yml` file is now being included if the `BROWSERTESTS_IMAGE` environment variable is being used.

Verified that the dev environment image is being used by testing the user `[[ $(whoami) == "root" ]]`
