### PR TITLE
WIP: Refactor Headless Handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ source 'https://rubygems.org'
 gem 'bundler-audit', require: false
 gem 'capybara'
 gem 'parallel_tests'
-gem 'phantomjs-helper'
-gem 'poltergeist'
 gem 'rake'
 gem 'rspec'
 gem 'rspec-retry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,11 +17,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (4.1.0)
-    cliver (0.3.2)
     diff-lcs (1.4.4)
-    ffi (1.15.4)
-    ffi-libarchive (1.1.3)
-      ffi (~> 1.0)
     matrix (0.4.2)
     mini_mime (1.1.2)
     nokogiri (1.12.5-x86_64-linux)
@@ -31,14 +27,6 @@ GEM
       parallel
     parser (3.0.2.0)
       ast (~> 2.4.1)
-    phantomjs-helper (1.1.0)
-      ffi-libarchive
-      nokogiri (~> 1.6)
-      rubyzip
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     public_suffix (4.0.6)
     racc (1.6.0)
     rack (2.2.3)
@@ -91,9 +79,6 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
-    websocket-driver (0.7.5)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -104,8 +89,6 @@ DEPENDENCIES
   bundler-audit
   capybara
   parallel_tests
-  phantomjs-helper
-  poltergeist
   rake
   rspec
   rspec-retry

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This framework contains support for...
 * Using Selenium Standalone containers eliminating the need
   for locally installed browsers or drivers
 * Multiple local browsers with automatic driver management
+* Headless execution for those browsers that support it
 * Single-command docker-compose framework to run
   the tests or a supplied command
 * Native through fully-containerized execution
@@ -52,7 +53,7 @@ You must have Docker installed and running on your local machine.
 
 ### To See the Tests Run Using the VNC Server
 > Browsers in the containers are not visible in the VNC server
-  when running `headless`.
+> when running headless
 
 The Selenium Standalone containers used in the docker-compose
 framework have an included VNC server for viewing and
@@ -137,22 +138,41 @@ Chrome be installed).
 #### Specify Browser
 `BROWSER=`...
 
+> **If the `BROWSER` environment variable is not provided (i.e. set),
+> then the default Capybara `:selenium` (Firefox) browser
+> is used**
+
 **Example:**
 `BROWSER=chrome`
 
-Currently the following browsers are supported in this project:
-* `chrome` - Google Chrome (requires Chrome and installs chromedriver if local)
-* `chrome_headless` - Google Chrome run in headless mode (requires Chrome > 59 and installs chromedriver if local)
-* `edge` - Microsoft Edge (requires Edge and installs edgedriver if local)
-* `firefox` - Mozilla Firefox (requires Firefox and installs geckodriver if local)
-* `firefox_headless` - Mozilla Firefox run in headless mode (requires Firefox and installs geckodriver if local)
-* `phantomjs` - PhantomJS headless browser (local only, installs PhantomJS)
+Mostly, this uses a _pass-through_ approach and should support any
+valid `Selenium::WebDriver` browser.
+
+The following browsers were working on Mac at the time of this commit...
+* `chrome` - Google Chrome (requires Chrome)
+* `edge` - Microsoft Edge (requires Edge)
+* `firefox` - Mozilla Firefox (requires Firefox)
 * `safari` - Apple Safari (local only, requires Safari)
 
 > This project uses the
 > [Webdrivers](https://github.com/titusfortner/webdrivers)
 > gem to automatically download and maintain chromedriver, edgedriver, and
 > geckodriver (Firefox).
+
+#### Specify Headless
+`HEADLESS=`...
+
+> **The `HEADLESS` environment variable is ignored if the `BROWSER`
+> environment variable is not provided (i.e. set)**
+
+**Example:**
+`HEADLESS=true`
+
+> The headless specification is implemented as _truthy_ (like Ruby)
+> and ignores case.  Setting `HEADLESS` to any value
+> including empty (i.e. `HEADLESS= `) is interpreted as `true`
+> except for the value `false`.  Thus, setting `HEADLESS=FALSE`
+> will **not** run headless.
 
 #### Specify Remote (Container) URL
 `REMOTE=`...
@@ -170,7 +190,7 @@ bundle exec rake
 ```
 
 > When running the tests locally natively using Rake, the tests are run in
-> parallel **unless** the Safari browser is chosen.
+> parallel **unless** the Safari browser is chosen
 
 ```
 bundle exec rspec
@@ -178,7 +198,7 @@ bundle exec rspec
 
 #### Local Browsers
 ```
-BROWSER=chrome_headless bundle exec rake
+BROWSER=chrome HEADLESS=true bundle exec rake
 ```
 
 #### Using the Selenium Standalone Containers
@@ -237,5 +257,4 @@ These tests use the...
 * SitePrism page object gem: [SitePrism docs](http://www.rubydoc.info/gems/site_prism/index),
 [SitePrism on github](https://github.com/natritmeyer/site_prism)
 * Webdrivers browser driver helper gem: [Webdrivers on github](https://github.com/titusfortner/webdrivers)
-* phantomjs-helper phantomjs driver helper gem: [phantomjs-helper on github](https://github.com/bergholdt/phantomjs-helper)
 * Selenium Standalone Debug Containers [Selenium HQ on Github](https://github.com/SeleniumHQ/docker-selenium)

--- a/docker-compose.selenium.yml
+++ b/docker-compose.selenium.yml
@@ -3,6 +3,7 @@ services:
   browsertests:
     environment:
       - BROWSER=${BROWSER:-chrome}
+      - HEADLESS=${HEADLESS-false}
       - REMOTE=http://${SELENIUM_HOSTNAME:-seleniumbrowser}:4444/wd/hub
       - REMOTE_STATUS=http://${SELENIUM_HOSTNAME:-seleniumbrowser}:4444/wd/hub/status
     command: ./script/runtests

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,67 +1,11 @@
 # frozen_string_literal: true
 
 require 'capybara'
-require 'capybara/poltergeist'
 require 'capybara/rspec'
 require 'selenium/webdriver'
 require 'site_prism'
+require 'support/capybara_browser'
 require 'webdrivers'
-
-# Capybara has pre-registered drivers for chrome and firefox but
-# there is a name mapping
-# See capybara/registrations/drivers.rb
-CHROME_FIREFOX_TO_REGISTERED_CAPYBARA = Hash[
-  'firefox': :selenium,
-  'firefox_headless': :selenium_headless,
-  'chrome': :selenium_chrome,
-  'chrome_headless': :selenium_chrome_headless,
-  'phantomjs': :poltergeist
-]
-
-### METHODS ###
-def create_remote_browser(remote_url, browser)
-  Capybara.register_driver :remote_browser do |app|
-    driver_options = { browser: :remote, url: remote_url }.tap do |opts|
-      opts[:capabilities] = browser_options browser
-    end
-    Capybara::Selenium::Driver.new(app, **driver_options)
-  end
-  Capybara.default_driver = :remote_browser
-end
-
-def create_local_browser(browser)
-  capy_browser = (browser || :selenium).to_sym
-  capy_browser = CHROME_FIREFOX_TO_REGISTERED_CAPYBARA[capy_browser] || capy_browser
-  register_browser capy_browser unless capybara_registered_browser? capy_browser
-  Capybara.default_driver = capy_browser
-end
-
-def register_browser(browser)
-  Capybara.register_driver browser do |app|
-    driver_options = { browser: browser, timeout: 30 }.tap do |opts|
-      opts[:capabilities] = browser_options browser
-    end
-    Capybara::Selenium::Driver.new(app, **driver_options)
-  end
-end
-
-def browser_options(browser)
-  browser = browser.to_s.gsub(/\W/, '').capitalize
-  # e.g. Selenium::WebDriver::Chrome::Options.new
-  Selenium::WebDriver.const_get(browser).const_get('Options').new
-end
-
-def capybara_registered_browser?(browser)
-  CHROME_FIREFOX_TO_REGISTERED_CAPYBARA.flatten.include?(browser)
-end
-
-### MAIN ###
-## Set Browser ##
-if ENV['REMOTE']
-  create_remote_browser(ENV['REMOTE'], ENV['BROWSER'])
-else
-  create_local_browser(ENV['BROWSER'])
-end
 
 ## Configure Test Framework ##
 RSpec.configure do |config|

--- a/spec/support/capybara_browser.rb
+++ b/spec/support/capybara_browser.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+### METHODS ###
+def create_remote_browser(remote_url, browser)
+  Capybara.register_driver :remote_browser do |app|
+    driver_options = { browser: :remote, url: remote_url }.tap do |opts|
+      opts[:capabilities] = browser_options browser
+    end
+    Capybara::Selenium::Driver.new(app, **driver_options)
+  end
+  Capybara.default_driver = :remote_browser
+end
+
+def create_local_browser(browser)
+  # Use the default :selenium (Firefox) browser if no browser
+  # is specified
+  return (Capybara.default_driver = :selenium) unless browser
+
+  capy_browser = browser.to_sym
+  register_browser capy_browser
+  Capybara.default_driver = capy_browser
+end
+
+def register_browser(browser)
+  Capybara.register_driver browser do |app|
+    driver_options = { browser: browser, timeout: 30 }.tap do |opts|
+      opts[:capabilities] = browser_options browser
+    end
+    Capybara::Selenium::Driver.new(app, **driver_options)
+  end
+end
+
+def browser_options(browser)
+  browser = browser.to_s.gsub(/\W/, '').capitalize
+  # e.g. Selenium::WebDriver::Chrome::Options.new
+  options = Selenium::WebDriver.const_get(browser).const_get('Options').new
+  options.headless! if headless?
+  options
+end
+
+def headless?
+  headless = ENV['HEADLESS']
+  return false if headless.nil?
+
+  headless.to_s.downcase != 'false'
+end
+
+### MAIN ###
+## Set Browser ##
+if ENV['REMOTE']
+  create_remote_browser(ENV['REMOTE'], ENV['BROWSER'])
+else
+  create_local_browser(ENV['BROWSER'])
+end


### PR DESCRIPTION
# What
This change set refactors the browser creation to fully support running headless using the `HEADLESS` environment variable instead of a `_headless` indicator in the `BROWSER` environment variable.  This now allows for running headless in remote (container) browsers.  This refactoring also changes the local browser creation from a "mapping" to Capybara registered browsers, to a "pass through" method, thus supporting any valid Capybara **Selenium** browser.

> This refactoring from "mapping" to Capybara registered browsers to a "pass-through" method of valid Capybara Selenium browsers, means that the non-Selenium driver `Poltergeist` i.e. PhantomJS browser is **no longer supported** by this project.  However, PhantomJS has been deprecated since 2018 in lieu of headless Chrome and Firefox etc.

In addition, the browser creation logic was moved out of the `spec-helper` file and into its own `support/capybara_browser` file.

# Why
This change set now provides full support for running headless in both local and remote (containerized) browsers as long as those browsers support it.

Moving to the pass-through method should provide lower maintenance efforts and automatic support for any valid Capybara Selenium browser. 

# Change Impact Analysis and Testing
This change set includes removing any PhantomJS/Poltergeist gems and a `bundle install` to remove these gems and any dependencies from `Gemfile.lock`.  
- [x] Native `bundle install` (macOS)
- [x] Container `bundle install` (CI)

This change set impacts both local and remote browser creation.
- [x] Remote browser creation (CI)
  - [x] Chrome
  - [x] Firefox
  - [x] Edge
- [x] Local browser creation
  - [x] default
  - [x] Chrome
  - [x] Firefox
  - [x] Edge
  - [x] Safari

This change set adds ability to specify running headless for those browsers that support it.
- [x] Local
- [x] Remote
- [x] `HEADLESS=` - runs headless
  - [x] Local
  - [x] docker-compose
- [x] `HEADLESS=foo` - runs headless
- [x] `HEADLESS=true` - runs headless
- [x] `HEADLESS=fAlSe` - does NOT run headless

This change set updates the README.
- [x] Updates visually inspected