### PR TITLE
Add Support for Running in Parallel in docker-compose

### DIFF
--- a/docker-compose.selenium.yml
+++ b/docker-compose.selenium.yml
@@ -13,12 +13,15 @@ services:
   seleniumbrowser :
     image: ${SELENIUM_IMAGE:-selenium/standalone-chrome:latest}
     container_name: ${SELENIUM_HOSTNAME:-seleniumbrowser}
-    shm_size: 2gb
+    shm_size: 4gb
     volumes:
       - /dev/shm:/dev/shm
     ports:
       - "5900:5900"
       - "7900:7900"
+    environment:
+      - SE_NODE_OVERRIDE_MAX_SESSIONS=true
+      - SE_NODE_MAX_SESSIONS=2
     healthcheck:
       test: ["CMD-SHELL", '/opt/bin/check-grid.sh --host 0.0.0.0 --port 4444']
       interval: 15s


### PR DESCRIPTION
# What
Added support for running specs in parallel in docker-compose.

# Why
Demonstrates how the `parallel_tests` gem can be levered in docker-compose (CI/CD).

# Change Impact Analysis and Testing
Tested in dev environment by watching VNC server.  This is not used (yet) in GH Actions.
