### PR TITLE
Some Cleanup

### DIFF
--- a/.github/workflows/check_development_environment.yml
+++ b/.github/workflows/check_development_environment.yml
@@ -49,7 +49,7 @@ jobs:
         run: "docker build --no-cache --target ${DEVENV} -t ${BROWSERTESTS_IMAGE} ."
 
       - name: dockercomposerun (Run tests) with defaults
-        run: BROWSERTESTS_SRC=${PWD} ./script/dockercomposerun
+        run: ./script/dockercomposerun
 
   runtests-specified-firefox:
     needs: build-devenv
@@ -67,7 +67,7 @@ jobs:
         run: "docker build --no-cache --target ${DEVENV} -t ${BROWSERTESTS_IMAGE} ."
 
       - name: dockercomposerun (Run tests) with Firefox
-        run: BROWSERTESTS_SRC=${PWD} ./script/dockercomposerun
+        run: ./script/dockercomposerun
 
   run-tests-specified-edge:
     needs: build-devenv
@@ -85,4 +85,4 @@ jobs:
         run: "docker build --no-cache --target ${DEVENV} -t ${BROWSERTESTS_IMAGE} ."
 
       - name: dockercomposerun (Run tests) with Edge
-        run: BROWSERTESTS_SRC=${PWD} ./script/dockercomposerun
+        run: ./script/dockercomposerun

--- a/README.md
+++ b/README.md
@@ -250,8 +250,16 @@ To run the development environment in the docker-compose environment,
 with a Selenium Standalone container use the `dockercomposerun`
 script and run it interactively with the default shell `/bin/ash`...
 ```
+BROWSERTESTS_IMAGE=browsertests-dev ./script/dockercomposerun /bin/ash
+```
+
+To use another directory as the source code for the development
+environment, set the `BROWSERTESTS_SRC` environment variable.
+For example...
+```
 BROWSERTESTS_IMAGE=browsertests-dev BROWSERTESTS_SRC=${PWD} ./script/dockercomposerun /bin/ash
 ```
+
 ## Sources and Additional Information
 These tests use the...
 * SitePrism page object gem: [SitePrism docs](http://www.rubydoc.info/gems/site_prism/index),

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,4 +3,4 @@ services:
   browsertests:
     image: "${BROWSERTESTS_IMAGE}"
     volumes:
-      - ${BROWSERTESTS_SRC}:/app
+      - ${BROWSERTESTS_SRC:-.}:/app

--- a/docker-compose.selenium.yml
+++ b/docker-compose.selenium.yml
@@ -3,7 +3,7 @@ services:
   browsertests:
     environment:
       - BROWSER=${BROWSER:-chrome}
-      - HEADLESS=${HEADLESS-false}
+      - HEADLESS
       - REMOTE=http://${SELENIUM_HOSTNAME:-seleniumbrowser}:4444/wd/hub
       - REMOTE_STATUS=http://${SELENIUM_HOSTNAME:-seleniumbrowser}:4444/wd/hub/status
     command: ./script/runtests

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-require 'capybara'
-require 'capybara/rspec'
-require 'selenium/webdriver'
 require 'site_prism'
 require 'support/capybara_browser'
-require 'webdrivers'
 
 ## Configure Test Framework ##
 RSpec.configure do |config|

--- a/spec/support/capybara_browser.rb
+++ b/spec/support/capybara_browser.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+require 'capybara'
+require 'capybara/rspec'
+require 'selenium/webdriver'
+require 'webdrivers'
+
 ### METHODS ###
 def create_remote_browser(remote_url, browser)
   Capybara.register_driver :remote_browser do |app|


### PR DESCRIPTION
# What
This change set does some cleanup and simple improvements, specifically...
  - Moves the Capybara (browser) related dependencies out of the `spec_helper` and into the Capybara browser support file
  - Changes the handling of the `HEADLESS` environment variable in `docker-compose.selenium.yml` to use the calling environment's `HEADLESS` environment variable instead of setting a default if not set - this makes the state of the `HEADLESS` environment variable exactly match the state in the calling environment (i.e. unset in the container if unset in the calling environment
  - Sets the current directory as the mounted source volume as the default in the development environment so that the user does not have to always specify it.

# Why
Improve code quality, usability, and transparency. 

# Change Impact Analysis and Testing
  - Moving the Capybara (browser) related dependencies impacts browser creation and was vetted by CI
  - Changing the `HEADLESS` environment variable was vetted manually using `dockercomposerun` and inspecting the state of the `HEADLESS` environment variable in the container and functionally using VNC.
  - Setting the  current directory as the mounted source volume as the default was vetted by CI
  - README updates were vetted by visually inspecting the rendered README on the branch
