### PR TITLE
Add Basic Secret Management

### DIFF
--- a/.github/workflows/check_deployable.yml
+++ b/.github/workflows/check_deployable.yml
@@ -50,6 +50,9 @@ jobs:
   run-tests-default-chrome:
     needs: build-deploy
     runs-on: ubuntu-latest
+    env:
+      LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
+      LOGIN_PASSWORD: ${{ secrets.LOGIN_PASSWORD }}
 
     steps:
       - uses: actions/checkout@v1
@@ -62,6 +65,8 @@ jobs:
     env:
       BROWSER: firefox
       SELENIUM_IMAGE: selenium/standalone-firefox:latest
+      LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
+      LOGIN_PASSWORD: ${{ secrets.LOGIN_PASSWORD }}
 
     steps:
       - uses: actions/checkout@v1
@@ -74,6 +79,8 @@ jobs:
     env:
       BROWSER: edge
       SELENIUM_IMAGE: selenium/standalone-edge:latest
+      LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
+      LOGIN_PASSWORD: ${{ secrets.LOGIN_PASSWORD }}
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/check_development_environment.yml
+++ b/.github/workflows/check_development_environment.yml
@@ -39,6 +39,9 @@ jobs:
   run-tests-default-chrome:
     needs: build-devenv
     runs-on: ubuntu-latest
+    env:
+      LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
+      LOGIN_PASSWORD: ${{ secrets.LOGIN_PASSWORD }}
 
     steps:
       - uses: actions/checkout@v1
@@ -57,6 +60,8 @@ jobs:
     env:
       BROWSER: firefox
       SELENIUM_IMAGE: selenium/standalone-firefox:latest
+      LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
+      LOGIN_PASSWORD: ${{ secrets.LOGIN_PASSWORD }}
 
     steps:
       - uses: actions/checkout@v1
@@ -75,6 +80,8 @@ jobs:
     env:
       BROWSER: edge
       SELENIUM_IMAGE: selenium/standalone-edge:latest
+      LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
+      LOGIN_PASSWORD: ${{ secrets.LOGIN_PASSWORD }}
 
     steps:
       - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ This framework contains support for...
 * Continuous Integration with GitHub Actions vetting
   linting, static security scanning, and functional
   tests
+* Basic secrets management using environment variables and
+  [GitHub Secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
 
 ## To Run the Automated Tests in Docker
 The easiest way to run the tests is with the docker-compose
@@ -49,7 +51,13 @@ You can view the running tests, using the included
 Virtual Network Computing (VNC) server.
 
 ### Prerequisites
-You must have Docker installed and running on your local machine.
+1. You must have Docker installed and running on your local machine.
+2. You must specify the login credentials (i.e. secrets) used in the
+   test with the `LOGIN_USERNAME` and `LOGIN_PASSWORD` environment
+   variables...
+   ```
+   LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword!
+   ```
 
 ### To See the Tests Run Using the VNC Server
 > Browsers in the containers are not visible in the VNC server
@@ -78,7 +86,7 @@ For more information, see the Selenium Standalone Image
    script with the defaults...
 
    ```
-   ./script/dockercomposerun
+   LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun
    ```
 
 ### To Run Using the Firefox Standalone Container
@@ -87,7 +95,7 @@ For more information, see the Selenium Standalone Image
    script setting the `BROWSER` and `SELENIUM_IMAGE`
    environment variables to specify Firefox...
    ```
-   BROWSER=firefox SELENIUM_IMAGE=selenium/standalone-firefox ./script/dockercomposerun
+   BROWSER=firefox SELENIUM_IMAGE=selenium/standalone-firefox LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun
    ```
 
 ### To Run Using the Edge Standalone Container
@@ -96,7 +104,7 @@ For more information, see the Selenium Standalone Image
    script setting the `BROWSER` and `SELENIUM_IMAGE`
    environment variables to specify Edge...
    ```
-   BROWSER=edge SELENIUM_IMAGE=selenium/standalone-edge ./script/dockercomposerun
+   BROWSER=edge SELENIUM_IMAGE=selenium/standalone-edge LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun
    ```
 
 ### To Run the Test Container Interactively (i.e. "Shell In")
@@ -104,7 +112,7 @@ For more information, see the Selenium Standalone Image
 2. From the project root directory, run the `dockercomposerun`
    script and supply the shell command `sh`...
    ```
-   ./script/dockercomposerun sh
+   LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun sh
    ```
 3. Run desired commands in the container
    (e.g. `bundle exec rake`)
@@ -135,6 +143,16 @@ Chrome be installed).
    ```
 
 ### Environment Variables
+
+#### Required Secrets
+`LOGIN_USERNAME=tomsmith`
+`LOGIN_PASSWORD=SuperSecretPassword!`
+
+**These must be set for the login test to pass.**
+
+> These are publicly available values but demonstrate
+> basic secret management
+
 #### Specify Browser
 `BROWSER=`...
 
@@ -186,19 +204,19 @@ specified by `BROWSER` at the specified remote URL
 ### Examples of Running the Tests
 #### Defaults
 ```
-bundle exec rake
+LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! bundle exec rake
 ```
 
 > When running the tests locally natively using Rake, the tests are run in
 > parallel **unless** the Safari browser is chosen
 
 ```
-bundle exec rspec
+LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! bundle exec rspec
 ```
 
 #### Local Browsers
 ```
-BROWSER=chrome HEADLESS=true bundle exec rake
+BROWSER=chrome HEADLESS=true LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! bundle exec rake
 ```
 
 #### Using the Selenium Standalone Containers
@@ -216,7 +234,7 @@ For specifics, see the Selenium Standalone Image
 2. If you want, launch the VNC client in app or browser
 3. Run the tests specifying the remote Selenium container...
    ```
-   REMOTE='http://localhost:4444/wd/hub' BROWSER=chrome bundle exec rspec
+   REMOTE='http://localhost:4444/wd/hub' BROWSER=chrome LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! bundle exec rspec
    ```
 
 ## Development
@@ -250,14 +268,14 @@ To run the development environment in the docker-compose environment,
 with a Selenium Standalone container use the `dockercomposerun`
 script and run it interactively with the default shell `/bin/ash`...
 ```
-BROWSERTESTS_IMAGE=browsertests-dev ./script/dockercomposerun /bin/ash
+BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun /bin/ash
 ```
 
 To use another directory as the source code for the development
 environment, set the `BROWSERTESTS_SRC` environment variable.
 For example...
 ```
-BROWSERTESTS_IMAGE=browsertests-dev BROWSERTESTS_SRC=${PWD} ./script/dockercomposerun /bin/ash
+BROWSERTESTS_SRC=${PWD} BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun /bin/ash
 ```
 
 ## Sources and Additional Information

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,6 @@ services:
     container_name: ${BROWSERTESTS_HOSTNAME:-browsertests}
     volumes:
       - .:/app
+    environment:
+      - LOGIN_USERNAME
+      - LOGIN_PASSWORD

--- a/spec/features/site_prism/login_page.rb
+++ b/spec/features/site_prism/login_page.rb
@@ -9,8 +9,8 @@ class LoginPage < SitePrism::Page
   elements :submit_button,  'button[type=submit]'
 
   def login_with_valid_credentials
-    username_input[0].set 'tomsmith'
-    password_input[0].set 'SuperSecretPassword!'
+    username_input[0].set ENV['LOGIN_USERNAME']
+    password_input[0].set ENV['LOGIN_PASSWORD']
     submit_button[0].click
   end
 end


### PR DESCRIPTION
# What
Adds very basic secret management using environment variables for the (publicly available) credentials for the login test. 

Uses separately created [GitHub Secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) to set the new secret environment variables in the GitHub Actions Continuous Integration (CI).

# Why
This is to demonstrate basic secret management.

# Change Impact Analysis and Testing
  - Changing the credentials from hard-coded strings to environment variables is in the page object for the login page and is only used in the login test
    - Any run of the login test would vet this
    - Tested that it fails if new secret environment variables are not set
    - Tested that it worked when new secret environment variables are set
  - Adding the environment variables to `docker-compose.yml` 
    - Tested that it fails if new secret environment variables are not set
    - Tested that it worked when new secret environment variables are set
  - Adding setting environment variables using GitHub Secrets in GitHub Actions
    - Tested that it failed before GH Secrets were created
    - Tested that it worked when GH Secrets were created