### PR TITLE
Move CI (Lint and Static Security Scanning) from Dockerfile to Outside Calls (docker-compose)

### DIFF
--- a/.github/workflows/check_deployable.yml
+++ b/.github/workflows/check_deployable.yml
@@ -10,30 +10,43 @@ env:
   # Use Docker Buildkit for builds
   DOCKER_BUILDKIT: 1
   COMPOSE_DOCKER_CLI_BUILD: 1
+  BROWSERTESTS_IMAGE: app
 
 jobs:
 
   code-standards-rubocop:
     runs-on: ubuntu-latest
+    env:
+      DEVENV: devenv
+      BROWSERTESTS_IMAGE: app-devenv
 
     steps:
       - uses: actions/checkout@v1
       - name: Docker version
         run: docker --version
 
-      - name: Build linted app code deploy
-        run: docker build --no-cache --target lint -t app-lint .
+      - name: Build app development environment
+        run: "docker build --no-cache --target ${DEVENV} -t ${BROWSERTESTS_IMAGE} ."
+
+      - name: Run linting script in dev environment image
+        run: ./script/dockercomposerun  -n -d ./script/runlint
 
   security-scan-bundler-audit:
     runs-on: ubuntu-latest
+    env:
+      DEVENV: devenv
+      BROWSERTESTS_IMAGE: app-devenv
 
     steps:
       - uses: actions/checkout@v1
       - name: Docker version
         run: docker --version
 
-      - name: Build security-scanned app code for deploy
-        run: docker build --no-cache --target secscan -t app-secscan .
+      - name: Build app development environment
+        run: "docker build --no-cache --target ${DEVENV} -t ${BROWSERTESTS_IMAGE} ."
+
+      - name: Run security scanning script in dev environment image
+        run:  ./script/dockercomposerun -n -d ./script/runsecscan
 
   build-deploy:
     needs: [code-standards-rubocop, security-scan-bundler-audit]
@@ -45,7 +58,7 @@ jobs:
         run: docker --version
 
       - name: Build app deploy
-        run: docker build --no-cache -t app .
+        run: docker build --no-cache -t ${BROWSERTESTS_IMAGE} .
 
   run-tests-default-chrome:
     needs: build-deploy
@@ -56,8 +69,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+
+      - name: Build app deploy
+        run: docker build --no-cache -t ${BROWSERTESTS_IMAGE} .
+
       - name: dockercomposerun (Run tests) with defaults
-        run: ./script/dockercomposerun
+        run: ./script/dockercomposerun -c
 
   run-tests-specified-firefox:
     needs: build-deploy
@@ -70,8 +87,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+
+      - name: Build app deploy
+        run: docker build --no-cache -t ${BROWSERTESTS_IMAGE} .
+
       - name: dockercomposerun (Run tests) with Firefox
-        run: ./script/dockercomposerun
+        run: ./script/dockercomposerun -c
 
   run-tests-specified-edge:
     needs: build-deploy
@@ -84,5 +105,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+
+      - name: Build app deploy
+        run: docker build --no-cache -t ${BROWSERTESTS_IMAGE} .
+
       - name: dockercomposerun (Run tests) with Edge
-        run: ./script/dockercomposerun
+        run: ./script/dockercomposerun -c

--- a/.github/workflows/check_development_environment.yml
+++ b/.github/workflows/check_development_environment.yml
@@ -52,7 +52,7 @@ jobs:
         run: "docker build --no-cache --target ${DEVENV} -t ${BROWSERTESTS_IMAGE} ."
 
       - name: dockercomposerun (Run tests) with defaults
-        run: ./script/dockercomposerun
+        run: ./script/dockercomposerun -d ./script/runtests
 
   runtests-specified-firefox:
     needs: build-devenv
@@ -72,7 +72,7 @@ jobs:
         run: "docker build --no-cache --target ${DEVENV} -t ${BROWSERTESTS_IMAGE} ."
 
       - name: dockercomposerun (Run tests) with Firefox
-        run: ./script/dockercomposerun
+        run: ./script/dockercomposerun -d ./script/runtests
 
   run-tests-specified-edge:
     needs: build-devenv
@@ -92,4 +92,4 @@ jobs:
         run: "docker build --no-cache --target ${DEVENV} -t ${BROWSERTESTS_IMAGE} ."
 
       - name: dockercomposerun (Run tests) with Edge
-        run: ./script/dockercomposerun
+        run: ./script/dockercomposerun -d ./script/runtests

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,21 +24,6 @@ RUN apk add --no-cache vim
 # Start devenv in (command line) shell
 CMD sh
 
-### Lint Stage ###
-FROM builder AS lint
-COPY . .
-RUN bundle exec rake rubocop
-
-### Security Static Scan Stage ###
-# Explicit dependencies (altho redundant with devenv)
-# Keep build dependencies
-FROM builder AS secscan
-# Add git for bundler-audit
-RUN apk add --no-cache git
-# Just need Rakefile and Gemfile.lock
-COPY Rakefile ./
-RUN bundle exec rake bundle:audit
-
 ### Deploy Stage ###
 FROM ruby-alpine AS deploy
 # Throw errors if Gemfile has been modified since Gemfile.lock
@@ -48,11 +33,11 @@ RUN bundle config --global frozen 1
 RUN adduser -D deployer
 USER deployer
 
-# Copy over the built gems directory from the scanned layer
-COPY --from=secscan --chown=deployer /usr/local/bundle/ /usr/local/bundle/
-# Copy in app source from the lint layer
+# Copy the built gems directory from builder layer
+COPY --from=builder --chown=deployer /usr/local/bundle/ /usr/local/bundle/
+# Copy the app source to /app
 WORKDIR /app
-COPY --from=lint --chown=deployer /app/ /app/
+COPY --chown=deployer . /app/
 
-# To Run the tests - altho this is orchestrated by the docker-compose.yml file
-#CMD bundle exec rake
+# Run the tests but allow override
+CMD ./script/runtests

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This framework contains support for...
 The easiest way to run the tests is with the docker-compose
 framework using the `dockercomposerun` script.
 
-This will build a docker image of this project and run
+This will pull the latest docker image of this project and run
 the tests against a
 [Selenium Standalone](https://github.com/SeleniumHQ/docker-selenium)
 container.
@@ -252,8 +252,8 @@ For specifics, see the Selenium Standalone Image
    ```
 
 ## Development
-This project can be developed locally or using the supplied basic,
-container-based development environment which include `vim` and `git`.
+This project can be developed using the supplied basic, container-based
+ development environment which include `vim` and `git`.
 
 ### To Develop Using the Container-based Development Environment
 To develop using the supplied container-based development environment...
@@ -262,35 +262,59 @@ To develop using the supplied container-based development environment...
    ```
    docker build --no-cache --target devenv -t browsertests-dev .
    ```
-2. Run the development environment image either on its own or
-   in the docker-compose environment with either the Selenium Chrome
-   or Firefox container.  By default the development environment
-   container executes the `/bin/ash` shell providing a command
-   line interface. When running the development environment
-   container, you must specify the path to this project's
-   source code.
+2. Run the development environment image in the docker-compose
+   environment either on its own or with either the Selenium
+   Chrome or Firefox container.  By default the development
+   environment container executes the `/bin/ash` shell providing
+   a command line interface.The development environment
+   container volume mounts in the source code.
 
 #### Running Just the Test Development Image
-To run the development environment on its own, use
-`docker run`...
+To run the development environment on its own in the docker-compose
+environment without a Selenium browser, use the `-n` option for
+no Selenium and the `-d` option for the development environment
+and specify the development environment image `BROWSERTESTS_IMAGE`...
 ```
-docker run -it --rm -v $(pwd):/app browsertests-dev
+BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -n -d
 ```
 
-#### Running the Test Development Image in docker-compose
+#### Running the Test Development Image With the Selenium Browser
 To run the development environment in the docker-compose environment,
 with a Selenium Standalone container use the `dockercomposerun`
-script and run it interactively with the default shell `/bin/ash`...
+script and the `-d` option for the development environment
+and specify the development environment image `BROWSERTESTS_IMAGE`
 ```
-BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun /bin/ash
+BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -d
 ```
 
 To use another directory as the source code for the development
 environment, set the `BROWSERTESTS_SRC` environment variable.
 For example...
 ```
-BROWSERTESTS_SRC=${PWD} BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun /bin/ash
+BROWSERTESTS_SRC=${PWD} BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -d
 ```
+
+#### Running the Tests, Linting and Security Scanning in Test Development Image
+To run the tests, linting, and security scanning in the development
+environment like CI, use the appropriate wrapper scripts.
+
+If you are running interactively (command line) in the development
+environment...
+
+* To run the **tests**...
+  ```
+  ./script/runtests
+  ```
+
+* To run the **linting**...
+  ```
+  ./script/runlint
+  ```
+
+* To run the dependency **security scan**...
+  ```
+  ./script/runsecscan
+  ```
 
 ## Sources and Additional Information
 These tests use the...

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,4 @@
+version: '3.4'
+services:
+  browsertests:
+    image: "${BROWSERTESTS_IMAGE}"

--- a/docker-compose.selenium.yml
+++ b/docker-compose.selenium.yml
@@ -6,7 +6,6 @@ services:
       - HEADLESS
       - REMOTE=http://${SELENIUM_HOSTNAME:-seleniumbrowser}:4444/wd/hub
       - REMOTE_STATUS=http://${SELENIUM_HOSTNAME:-seleniumbrowser}:4444/wd/hub/status
-    command: ./script/runtests
     depends_on:
       - seleniumbrowser
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   browsertests:
-    build: .
+    image: brianjbayer/sample-login-capybara-rspec:${BROWSERTESTS_TAG:-latest}
     container_name: ${BROWSERTESTS_HOSTNAME:-browsertests}
     environment:
       - LOGIN_USERNAME

--- a/script/dockercomposerun
+++ b/script/dockercomposerun
@@ -1,16 +1,58 @@
 #!/bin/sh
+
+# ----------------------------------------------------------------------
 # This script runs the project docker-compose framework.
 #
 # - The arguments to this script are passed to the browsertests service
-#   as command override
+#   as the command override
 #
 # - Any environment variables set when calling this script are passed
 #   through to the docker-compose framework
-#   (e.g. configuration other than the defaults
+#   (e.g. configuration other than the defaults)
 #
+# OPTIONS:
+# -c: Use the docker-compose CI environment with BROWSERTESTS_IMAGE
+# -d: Use the docker-compose Dev environment with BROWSERTESTS_IMAGE
+# -n: No Selenium browser in the docker-compose environment
+# ----------------------------------------------------------------------
 
+usage() {
+  echo "Usage: $0 [-cdn] [CMD]"
+}
+
+err_exit() {
+  local err_msg="$1"
+  local err_code=$2
+  echo "${err_msg}  --  Exit:[${err_code}]" 1>&2
+  usage
+  exit $err_code
+}
+
+# --- MAIN --- #
 # Exit script on any errors
 set -e
+
+# Handle options
+while getopts ":cdn" options; do
+  case "${options}" in
+    c)
+      echo "CI Environment"
+      ci=true
+      ;;
+    d)
+      echo "Development Environment"
+      devenv=true
+      ;;
+    n)
+      echo "No Selenium"
+      noselenium=true
+      ;;
+    \?)
+    err_exit "Invalid Option: -$OPTARG" 1
+      ;;
+  esac
+done
+shift $((OPTIND-1))
 
 echo ''
 echo "ENVIRONMENT VARIABLES..."
@@ -22,9 +64,23 @@ docker --version
 docker-compose --version
 echo ''
 
+# Override docker compose environments
 echo 'DOCKER-COMPOSE COMMAND...'
+
+# By default include the Selenium browser in the ocker compose environment
 docker_compose_command='docker-compose -f docker-compose.yml -f docker-compose.selenium.yml '
-if [ ! -z ${BROWSERTESTS_IMAGE} ]; then
+
+if [ ! -z ${noselenium} ]; then
+  echo "...No Selenium Browser in Environment"
+docker_compose_command='docker-compose -f docker-compose.yml '
+fi
+
+if [ ! -z ${ci} ]; then
+  echo "...Using CI Environment with Image [${BROWSERTESTS_IMAGE}]"
+  docker_compose_command="${docker_compose_command} -f docker-compose.ci.yml "
+fi
+
+if [ ! -z ${devenv} ]; then
   echo "...Using Development Environment with Image [${BROWSERTESTS_IMAGE}]"
   docker_compose_command="${docker_compose_command} -f docker-compose.dev.yml "
 fi

--- a/script/runlint
+++ b/script/runlint
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Exit script on any errors
+set -e
+
+run_command='bundle exec rake rubocop'
+echo "RUNNING [${run_command}]..."
+# Allow to fail but catch return code
+set +e
+$run_command
+run_return_code=$?
+# NOTE return code must be caught before any other command
+set -e
+echo ''
+
+echo "EXITING WITH RUN RETURN CODE [${run_return_code}]"
+exit $run_return_code

--- a/script/runsecscan
+++ b/script/runsecscan
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Exit script on any errors
+set -e
+
+run_command='bundle exec bundle-audit check --update'
+echo "RUNNING [${run_command}]..."
+# Allow to fail but catch return code
+set +e
+$run_command
+run_return_code=$?
+# NOTE return code must be caught before any other command
+set -e
+echo ''
+
+echo "EXITING WITH RUN RETURN CODE [${run_return_code}]"
+exit $run_return_code


### PR DESCRIPTION
# What
This refactors the CI actions (here linting and security scanning) out of the image building with the `Dockerfile` and
into the CI itself.

It also updates the base `docker-compose.yml`file to pull a "production" image instead of building one.

Finally a `CMD` is added to the deployment/production image to run the tests instead
of having the command in the docker-compose files.

# Why
This puts the CI where it should be and prepares for the upcoming PR to add image-based CI/CD.

# Change Impact Analysis and Testing
## Refactor Dockerfile
- [x] Refactor Dockerfile to remove linting and static security scanning
  - [x] Tested in CI with visual inspection of output
- [x] Update deployment/production image to have CMD to `./script/runtests`
  - [x] Tested in CI with visual inspection of output of deployment default runtests
- [x] Remove `command` to `./script/runtests` in `docker-compose.selenium.yml`
  - [x] Tested in CI with visual inspection of output of deployment default runtests

## Add Simple Scripts for Linting, Scanning
- [x] Script to run linting with return code
  - [x] Tested in CI with visual inspection of output
- [x] Script to run sec scan with return code
  - [x] Tested in CI with visual inspection of output

## Refactor Docker Compose Framework
- [x] Use Image (with default name) instead of building (TAG env)
  - [x] Tested manually without and with `BROWSER_TESTS_TAG`
- [x] Add `docker-compose.ci.yml` to just override image (not vol mount in devenv)
  - [x] Tested in CI to run lint, sec scan, and tests by visual inspection of output (docker compose config)
- [x] Refactor devenv and CI environments in `dockercomposerun` to use opts
  - [x] Tested in CI to run lint, sec scan, and tests
- [x] Add no-selenium-browser opt to `dockercomposerun` for running linting and sec scan w/o Selenium image
  - [x] Tested in CI with (lint, secscan) and without (browser tests)

## Refactor GitHub Actions
- [x] Build devenv image and run linting - no selenium, devenv
  - [x] Tested in CI with visual inspection of output
- [x] Build devenv image and run sec scan - no selenium, devenv
  - [x] Tested in CI with visual inspection of output
- [x] Build deploy and run tests, ci env
  - [x] Tested in CI with visual inspection of output

