### PR TITLE
Update for image based

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,40 +253,52 @@ For specifics, see the Selenium Standalone Image
 
 ## Development
 This project can be developed using the supplied basic, container-based
- development environment which include `vim` and `git`.
+development environment which includes `vim` and `git`.
 
-### To Develop Using the Container-based Development Environment
-To develop using the supplied container-based development environment...
-1. Build the development environment image specifying the `devenv` build
+The development environment container volume mounts your local source
+code to recognize and persist any changes.
+
+By default the development environment container executes the alpine
+`/bin/ash` shell providing a command line interface.
+
+### To Develop Using the Container-Based Development Environment
+The easiest way to run the containerized development environment is with
+the docker-compose framework using the `dockercomposerun` script with the
+`-d` (development environment) option...
+```
+LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -d
+```
+
+This will pull and run the latest development environment image of this
+project along with the Chrome [Selenium Standalone](https://github.com/SeleniumHQ/docker-selenium)
+container.
+
+#### Running Just the Development Environment
+To run the development environment on its own in the docker-compose
+environment **without a Selenium browser**, use the `-n` option for
+no Selenium and the `-d` option for the development environment...
+```
+LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -n -d
+```
+
+#### Building Your Own Development Environment Image
+You can also build and run your own development environment image.
+
+1. Build your development environment image specifying the `devenv` build
    stage as the target and supplying a name (tag) for the image.
    ```
    docker build --no-cache --target devenv -t browsertests-dev .
    ```
-2. Run the development environment image in the docker-compose
+
+2. Run your development environment image in the docker-compose
    environment either on its own or with either the Selenium
-   Chrome or Firefox container.  By default the development
-   environment container executes the `/bin/ash` shell providing
-   a command line interface.The development environment
-   container volume mounts in the source code.
+   Chrome or Firefox container and specify your development
+   environment image with `BROWSERTESTS_IMAGE`
+   ```
+   BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -n -d
+   ```
 
-#### Running Just the Test Development Image
-To run the development environment on its own in the docker-compose
-environment without a Selenium browser, use the `-n` option for
-no Selenium and the `-d` option for the development environment
-and specify the development environment image `BROWSERTESTS_IMAGE`...
-```
-BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -n -d
-```
-
-#### Running the Test Development Image With the Selenium Browser
-To run the development environment in the docker-compose environment,
-with a Selenium Standalone container use the `dockercomposerun`
-script and the `-d` option for the development environment
-and specify the development environment image `BROWSERTESTS_IMAGE`
-```
-BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -d
-```
-
+#### Specifying the Source Code Location
 To use another directory as the source code for the development
 environment, set the `BROWSERTESTS_SRC` environment variable.
 For example...
@@ -294,7 +306,7 @@ For example...
 BROWSERTESTS_SRC=${PWD} BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -d
 ```
 
-#### Running the Tests, Linting and Security Scanning in Test Development Image
+#### Running the Tests, Linting, and Security Scanning
 To run the tests, linting, and security scanning in the development
 environment like CI, use the appropriate wrapper scripts.
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,6 @@
 version: '3.4'
 services:
   browsertests:
-    image: "${BROWSERTESTS_IMAGE}"
+    image: "${BROWSERTESTS_IMAGE:-brianjbayer/sample-login-capybara-rspec-dev:latest}"
     volumes:
       - ${BROWSERTESTS_SRC:-.}:/app


### PR DESCRIPTION
# What
This 2-file change set updates the dev environment to be (pull) image based instead of building your own.
  * The `docker-compose.dev.yml` was updated with a default of the latest dev environment image
  * The `README.md` was updated for the dev environment to be pulled by default

# Why
Post CI/CD where the dev environment image is produced.

# Change Impact Analysis and Testing

- [x] Manually tested per readme, default dev environment image
- [x] Visually inspected readme
