### PR TITLE
Refactor GitHub Actions on PR to use Matrix Strategies reducing 6 configurations into 2

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -62,39 +62,17 @@ jobs:
       - name: dockercomposerun bundle-audit on development environment
         run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -n -d ./script/runsecscan"
 
-  vet-e2e-tests-deploy-image-default-chrome:
+  vet-deploy-e2e-tests-matrix:
     needs: [pr-norm-branch, build-and-push-branch-unvetted]
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chrome, firefox, edge]
     runs-on: ubuntu-latest
     env:
       UNVETTED_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
-      LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
-      LOGIN_PASSWORD: ${{ secrets.LOGIN_PASSWORD }}
-    steps:
-      - uses: actions/checkout@v1
-      - name: dockercomposerun unvetted image
-        run: "BROWSERTESTS_IMAGE=${UNVETTED_IMAGE} ./script/dockercomposerun -c"
-
-  vet-e2e-tests-deploy-image-firefox:
-    needs: [pr-norm-branch, build-and-push-branch-unvetted]
-    runs-on: ubuntu-latest
-    env:
-      UNVETTED_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
-      BROWSER: firefox
-      SELENIUM_IMAGE: selenium/standalone-firefox:latest
-      LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
-      LOGIN_PASSWORD: ${{ secrets.LOGIN_PASSWORD }}
-    steps:
-      - uses: actions/checkout@v1
-      - name: dockercomposerun unvetted image
-        run: "BROWSERTESTS_IMAGE=${UNVETTED_IMAGE} ./script/dockercomposerun -c"
-
-  vet-e2e-tests-deploy-image-edge:
-    needs: [pr-norm-branch, build-and-push-branch-unvetted]
-    runs-on: ubuntu-latest
-    env:
-      UNVETTED_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
-      BROWSER: edge
-      SELENIUM_IMAGE: selenium/standalone-edge:latest
+      BROWSER: ${{ matrix.browser }}
+      SELENIUM_IMAGE: selenium/standalone-${{ matrix.browser }}:latest
       LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
       LOGIN_PASSWORD: ${{ secrets.LOGIN_PASSWORD }}
     steps:
@@ -107,9 +85,7 @@ jobs:
     needs:
       - vet-code-standards
       - vet-dependency-security
-      - vet-e2e-tests-deploy-image-default-chrome
-      - vet-e2e-tests-deploy-image-firefox
-      - vet-e2e-tests-deploy-image-edge
+      - vet-deploy-e2e-tests-matrix
       - pr-norm-branch
     uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
     with:
@@ -122,39 +98,17 @@ jobs:
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   # Vet Dev Environment Image
-  vet-e2e-tests-devenv-image-default-chrome:
+  vet-devenv-e2e-tests-matrix:
     needs: [pr-norm-branch, build-and-push-branch-devenv]
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chrome, firefox, edge]
     runs-on: ubuntu-latest
     env:
       DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
-      LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
-      LOGIN_PASSWORD: ${{ secrets.LOGIN_PASSWORD }}
-    steps:
-      - uses: actions/checkout@v1
-      - name: dockercomposerun devenv image
-        run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -d ./script/runtests"
-
-  vet-e2e-tests-devenv-image-firefox:
-    needs: [pr-norm-branch, build-and-push-branch-devenv]
-    runs-on: ubuntu-latest
-    env:
-      DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
-      BROWSER: firefox
-      SELENIUM_IMAGE: selenium/standalone-firefox:latest
-      LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
-      LOGIN_PASSWORD: ${{ secrets.LOGIN_PASSWORD }}
-    steps:
-      - uses: actions/checkout@v1
-      - name: dockercomposerun devenv image
-        run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -d ./script/runtests"
-
-  vet-e2e-tests-devenv-image-edge:
-    needs: [pr-norm-branch, build-and-push-branch-devenv]
-    runs-on: ubuntu-latest
-    env:
-      DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
-      BROWSER: edge
-      SELENIUM_IMAGE: selenium/standalone-edge:latest
+      BROWSER: ${{ matrix.browser }}
+      SELENIUM_IMAGE: selenium/standalone-${{ matrix.browser }}:latest
       LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
       LOGIN_PASSWORD: ${{ secrets.LOGIN_PASSWORD }}
     steps:


### PR DESCRIPTION
# What
Refactor the GitHub (GH) Actions on PR workflow to use GH Actions Matrix Strategies reducing the 6 end-2-end (e2e) tests configurations into 2 browser-based matrix configurations.

It was decided not to combine the two remaining e2e-test matrix configuration into one two-dimensional matrix configuration (based on the image name) because the deploy (candidate) image e2e tests have downstream jobs (push vetted image) dependent upon them and the devenv tests do not.

# Why
This reduces configuration by 3 to 1 and that configuration has a lot of duplication.  Condenses the essence of the e2e test configuration for easier understanding of the overall workflow

# Change Impact Analysis and Testing
This changes the running of the end-to-end selenium browser container tests in the github actions.
There are...
  - 2 different source images (deploy candidate and devenv) run against these tests
  - 3 different selenium browser images 
    1. chrome
    2. firefox
    3. edge

This change set impacts all of these.  

- [x] However there are only two matrix configurations which must be verified once each for the correct images being used...
  - [x] deploy candidate
  - [x] devenv
- [x] The browser configurations were verified from the actions logic working (using the matrix browser value in the browser and selenium image environment variables) and manual inspection
- [x] Failing deploy jobs were verified to stop dependent downstream jobs from starting
  - [x] Fast-fail is false verified that one job fail does not block running other jobs in matrix configuration

