### PR TITLE
Parameterize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,53 @@
-# sample-login-capybara-rspec
-### Base Image ###
-FROM ruby:2.7.7-alpine AS ruby-alpine
+#-----------------------------------
+#--- sample-login-capybara-rspec ---
+#-----------------------------------
 
-### Builder Stage ###
+#--- Base Image ---
+ARG BASE_IMAGE=ruby:2.7.7-alpine
+FROM ${BASE_IMAGE} AS ruby-alpine
+
+#--- Builder Stage ---
 FROM ruby-alpine AS builder
+
 # Alpine needs build-base for building native extensions
-RUN apk --update add --virtual build-dependencies build-base
+ARG BUILD_PACKAGES='build-dependencies build-base'
 
 # Use the same version of Bundler in the Gemfile.lock
-RUN gem install bundler:2.3.26
-WORKDIR /app
+ARG BUNDLER_VER=2.3.26
+
+RUN apk --update add --virtual ${BUILD_PACKAGES} \
+  && gem install bundler:${BUNDLER_VER}
+
 # Install the Ruby dependencies (defined in the Gemfile/Gemfile.lock)
+WORKDIR /app
 COPY Gemfile Gemfile.lock ./
 RUN bundle install
 
-### Dev Environment ###
-# Before any checks stages so that we can always build a dev env
+#--- Dev Environment ---
 # ASSUME source is docker volumed into the image
 FROM builder AS devenv
-# Add git and vim at least
-RUN apk add --no-cache git
-RUN apk add --no-cache vim
+
+# For Dev Env, add git and vim at least
+ARG DEVENV_PACKAGES='git vim'
+RUN apk --update add ${DEVENV_PACKAGES}
+
 # Start devenv in (command line) shell
 CMD sh
 
-### Deploy Stage ###
+#--- Deploy Stage ---
 FROM ruby-alpine AS deploy
+
 # Throw errors if Gemfile has been modified since Gemfile.lock
-RUN bundle config --global frozen 1
+RUN bundle config --global frozen 1 \
+# Add a user so not running as root
+  && adduser -D deployer
 
 # Run as deployer USER instead of as root
-RUN adduser -D deployer
 USER deployer
 
-# Copy the built gems directory from builder layer
+# Copy over the built gems (directory)
 COPY --from=builder --chown=deployer /usr/local/bundle/ /usr/local/bundle/
+
 # Copy the app source to /app
 WORKDIR /app
 COPY --chown=deployer . /app/


### PR DESCRIPTION
 # What
This non-functional changeset adds some parameterization with default values to the project `Dockerfile`, specifically...
  - Base image (e.g. `--build-arg BASE_IMAGE=...`)
  - Bundler version (e.g. `--build-arg BUNDLER_VER=...`)
  - Build packages to install (e.g.  `--build-arg BUILD_PACKAGES=...`)
  - Dev environment packages to install (e.g.  `--build-arg DEVENV_PACKAGES=...`)

# Why
This should make development more flexible, adding the ability to override these values without having to modify the `Dockerfile`.  It also hopefully makes the specific values more readable and apparent.

# Change Impact Analysis and Testing
This changeset impacts the building and proper operation of the image.

- [x] CI tests building and operating both the deploy and dev environment images
- [x] Manually tested overriding the Base Image and Bundler version (`docker build --build-arg BASE_IMAGE=ruby:2.7.6-alpine --build-arg BUNDLER_VER=2.3.25 --no-cache --target devenv -t browsertests-dev .`)
 