### PR TITLE
Update to SitePrism and RSpec Standards

### DIFF
--- a/spec/features/login_page_spec.rb
+++ b/spec/features/login_page_spec.rb
@@ -1,25 +1,29 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require_relative 'login_steps'
 require_relative 'site_prism/login_page'
 require_relative 'site_prism/secure_area_page'
 
-feature 'Login page' do
+describe 'Login page' do
+  # NOTE: Scenarios check visibility which implicitly checks presence
+
   let(:login_page) { LoginPage.new }
 
-  scenario 'login page must have single visible username and password input fields and submit button' do
-    user_goes_to_the_login_page
-    there_must_be_a_single_visible(login_page.username_input)
-    there_must_be_a_single_visible(login_page.password_input)
-    there_must_be_a_single_visible(login_page.submit_button)
+  before do
+    login_page.load
   end
 
-  #### SUPPORT METHODS ###
-  # TODO: This should probably be a common routine
-  def there_must_be_a_single_visible(elements)
-    expect(elements.count).to eq(1)
-    the_element = elements[0]
-    expect(the_element.visible?).to be true
+  it { expect(login_page).to be_displayed }
+
+  it 'has a visible username input' do
+    expect(login_page.username_input).to be_visible
+  end
+
+  it 'has a visible password input' do
+    expect(login_page.password_input).to be_visible
+  end
+
+  it 'has a visible submit button' do
+    expect(login_page.submit_button).to be_visible
   end
 end

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -21,12 +21,7 @@ feature 'User logs in' do
   end
 
   def user_must_be_sent_to_the_secure_area_page
-    # An "eventually" matcher
-    Timeout.timeout(5) do
-      sleep 0.1 until secure_area_page.current_url.eql?(secure_area_page.url)
-    end
-  rescue Timeout::Error
-    # One last chance or the actual expect error
-    expect(secure_area_page.current_url).to eq secure_area_page.url
+    # Expect the page to be loaded/displayed within 5 seconds
+    expect(secure_area_page.displayed?(5)).to be true
   end
 end

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -1,27 +1,20 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require_relative 'login_steps'
 require_relative 'site_prism/login_page'
 require_relative 'site_prism/secure_area_page'
 
 feature 'User logs in' do
-  let(:login_page)       { LoginPage.new }
-  let(:secure_area_page) { SecureAreaPage.new }
+  given(:login_page)       { LoginPage.new }
+  given(:secure_area_page) { SecureAreaPage.new }
 
-  scenario 'user logs in with valid credentials and is sent to the secure area' do
-    user_goes_to_the_login_page
-    user_logins_with_valid_credentials
-    user_must_be_sent_to_the_secure_area_page
+  background do
+    login_page.load
+    expect(login_page).to be_displayed
   end
-
-  ### STEPS ###
-  def user_logins_with_valid_credentials
+  scenario 'with valid credentials and is sent to the secure area' do
     login_page.login_with_valid_credentials
-  end
-
-  def user_must_be_sent_to_the_secure_area_page
-    # Expect the page to be loaded/displayed within 5 seconds
-    expect(secure_area_page.displayed?(5)).to be true
+    # Allow at least 5 seconds for page to load
+    expect(secure_area_page).to be_displayed(5)
   end
 end

--- a/spec/features/login_steps.rb
+++ b/spec/features/login_steps.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-### LOGIN STEPS ###
-
-def user_goes_to_the_login_page
-  login_page.load
-  expect(login_page).to be_displayed
-end

--- a/spec/features/login_steps.rb
+++ b/spec/features/login_steps.rb
@@ -4,4 +4,5 @@
 
 def user_goes_to_the_login_page
   login_page.load
+  expect(login_page).to be_displayed
 end

--- a/spec/features/site_prism/login_page.rb
+++ b/spec/features/site_prism/login_page.rb
@@ -4,9 +4,9 @@ class LoginPage < SitePrism::Page
   set_url 'http://the-internet.herokuapp.com/login'
 
   # NOTE: We create these as collections (altho we expect only one of each) so that we can verify expectation
-  elements :username_input, 'input[name=username]'
-  elements :password_input, 'input[name=password]'
-  elements :submit_button,  'button[type=submit]'
+  elements :username_input, 'input[id="username"]'
+  elements :password_input, 'input[id="password"]'
+  elements :submit_button,  'button[type="submit"]'
 
   def login_with_valid_credentials
     username_input[0].set ENV['LOGIN_USERNAME']

--- a/spec/features/site_prism/login_page.rb
+++ b/spec/features/site_prism/login_page.rb
@@ -3,14 +3,13 @@
 class LoginPage < SitePrism::Page
   set_url 'http://the-internet.herokuapp.com/login'
 
-  # NOTE: We create these as collections (altho we expect only one of each) so that we can verify expectation
-  elements :username_input, 'input[id="username"]'
-  elements :password_input, 'input[id="password"]'
-  elements :submit_button,  'button[type="submit"]'
+  element :username_input, 'input[id="username"]'
+  element :password_input, 'input[id="password"]'
+  element :submit_button, 'button[type="submit"]'
 
   def login_with_valid_credentials
-    username_input[0].set ENV['LOGIN_USERNAME']
-    password_input[0].set ENV['LOGIN_PASSWORD']
-    submit_button[0].click
+    username_input.set ENV.fetch('LOGIN_USERNAME')
+    password_input.set ENV.fetch('LOGIN_PASSWORD')
+    submit_button.click
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@ require 'capybara'
 require 'capybara/rspec'
 require 'selenium-webdriver'
 require 'site_prism'
-# require 'site_prism/all_there' # Optional but needed to perform more complex matching
 require 'support/capybara_browser'
 
 ## Configure Test Framework ##

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
+require 'capybara'
+require 'capybara/rspec'
+require 'selenium-webdriver'
 require 'site_prism'
+# require 'site_prism/all_there' # Optional but needed to perform more complex matching
 require 'support/capybara_browser'
 
 ## Configure Test Framework ##


### PR DESCRIPTION
# What
This changeset modifies the core tests to follow and use the documented [SitePrism](https://github.com/site-prism/site_prism) and RSpec standards.

# Why
This is to better ensure maintainability and follow good and expected code practices.

# Change Impact Analysis and Testing
These changes are limited to the tests themselves and does not impact any project infrastructure.

- [x] CI will vet current style guides for changed code
- [x] CI will vet functionality in the deployment and development environment containers ensuring no regressions
- [x] Manual native local execution of tests against all supported browsers will ensure no regressions at least on my machine (Intel macOS)
