### PR TITLE
Rubocop and Code Style Improvements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,5 @@
 AllCops:
-  NewCops: disable
+  NewCops: enable
+
 Layout/LineLength:
     Max: 120
-Metrics/MethodLength:
-  Max: 15

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,15 @@
+require:
+  - rubocop-rake
+  - rubocop-rspec
+
 AllCops:
   NewCops: enable
 
 Layout/LineLength:
     Max: 120
+
+# --- Rubocop RSpec Configuration ---
+
+# Allow Capybara "Gherkin" RSpec DSL
+RSpec/Capybara/FeatureMethods:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ gem 'rake'
 gem 'rspec'
 gem 'rspec-retry'
 gem 'rubocop', require: false
+gem 'rubocop-rake', require: false
+gem 'rubocop-rspec', require: false
 gem 'selenium-webdriver'
 gem 'site_prism'
 gem 'webdrivers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,10 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.24.0)
       parser (>= 3.1.1.0)
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
+    rubocop-rspec (2.16.0)
+      rubocop (~> 1.33)
     ruby-progressbar (1.11.0)
     rubyzip (2.3.2)
     selenium-webdriver (4.7.1)
@@ -95,6 +99,8 @@ DEPENDENCIES
   rspec
   rspec-retry
   rubocop
+  rubocop-rake
+  rubocop-rspec
   selenium-webdriver
   site_prism
   webdrivers

--- a/spec/support/capybara_browser.rb
+++ b/spec/support/capybara_browser.rb
@@ -39,21 +39,22 @@ def browser_options(browser)
   browser = browser.to_s.gsub(/\W/, '').capitalize
   # e.g. Selenium::WebDriver::Chrome::Options.new
   options = Selenium::WebDriver.const_get(browser).const_get('Options').new
-  options.headless! if headless?
+  options.headless! if headless_specified?
   options
 end
 
-def headless?
-  headless = ENV['HEADLESS']
-  return false if headless.nil?
-
+def headless_specified?
+  headless = ENV.fetch('HEADLESS', false)
   headless.to_s.downcase != 'false'
 end
 
 ### MAIN ###
 ## Set Browser ##
-if ENV['REMOTE']
-  create_remote_browser(ENV['REMOTE'], ENV['BROWSER'])
+remote_browser_url = ENV.fetch('REMOTE', nil)
+browser = ENV.fetch('BROWSER', nil)
+
+if remote_browser_url
+  create_remote_browser(remote_browser_url, browser)
 else
-  create_local_browser(ENV['BROWSER'])
+  create_local_browser(browser)
 end


### PR DESCRIPTION
# What
This changeset aims to improve the code style of this project and its enforcement using Rubocop.

Specifically....

- Rubocop `NewCops` was enabled and encountered code offenses resolved
- Rubocop extension `rubocop-rake` was added
- Rubocop extension `rubocop-rspec` was added

# Why
This changeset will improve and standardize the code style of this project.

# Change Impact Analysis and Testing

- [x] CI will vet the running and enforcement of the code standards
- [x] CI will vet the functionality of the deployment and development environment containers ensuring no regressions
- [x] Manual running of the functional tests for supported native browsers will ensure no regressions