### PR TITLE
Address Selenium [DEPRECATION] [:capabilities] Warning

### DIFF
--- a/spec/support/capybara_browser.rb
+++ b/spec/support/capybara_browser.rb
@@ -6,12 +6,10 @@ require 'selenium/webdriver'
 require 'webdrivers'
 
 ### METHODS ###
-def create_remote_browser(remote_url, browser)
+def create_remote_browser(url, browser)
   Capybara.register_driver :remote_browser do |app|
-    driver_options = { browser: :remote, url: remote_url }.tap do |opts|
-      opts[:capabilities] = browser_options browser
-    end
-    Capybara::Selenium::Driver.new(app, **driver_options)
+    options = browser_options(browser)
+    Capybara::Selenium::Driver.new(app, browser: :remote, options:, url:)
   end
   Capybara.default_driver = :remote_browser
 end
@@ -28,10 +26,8 @@ end
 
 def register_browser(browser)
   Capybara.register_driver browser do |app|
-    driver_options = { browser:, timeout: 30 }.tap do |opts|
-      opts[:capabilities] = browser_options browser
-    end
-    Capybara::Selenium::Driver.new(app, **driver_options)
+    options = browser_options(browser)
+    Capybara::Selenium::Driver.new(app, browser:, options:)
   end
 end
 
@@ -39,7 +35,7 @@ def browser_options(browser)
   browser = browser.to_s.gsub(/\W/, '').capitalize
   # e.g. Selenium::WebDriver::Chrome::Options.new
   options = Selenium::WebDriver.const_get(browser).const_get('Options').new
-  options.headless! if headless_specified?
+  options.add_argument('--headless') if headless_specified?
   options
 end
 


### PR DESCRIPTION
# What
This changeset makes no changes to existing behavior, but resolves the the following [Selenium Webdriver](https://github.com/SeleniumHQ/selenium) deprecations warning...
```
WARN Selenium [DEPRECATION] [:capabilities] The :capabilities parameter for Selenium::WebDriver::<browser>::Driver is deprecated. Use :options argument with an instance of Selenium::WebDriver::<browser>::Driver instead.
```

# Why
Selenium 4 has changed the way it handles `:capabilities`/`options` and setting headless and was issuing deprecation warnings for the way that this project handled creating local and remote drivers/browsers.  Although, these are only warnings now, this approach will be deprecated in the future, so the changes were made now.

# Change Impact Analysis and Testing
These changes are related to the Capybara browser creation and effect all browser creation both local and remote as well as headless.

- [x] Remote non-headless supported browsers are vetted for no regressions by CI
- [x] Local headless and non-headless supported browsers (on Mac) are vetted by manual testing of all browsers with and without headless (if supported)
- [x] Remote headless supported browsers are vetted by manual testing (since the code is common for all headless handling, only Edge was tested) 
