### PR TITLE
Abridge the README into Separate Documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # sample-login-capybara-rspec
 
 ## Overview
-This is an example of Acceptance Test Driven Development (ATDD) using
+This is an example of End-To-End (E2E) Tests/Acceptance Test
+Driven Development (ATDD) using
 [Capybara](https://github.com/teamcapybara/capybara),
 [RSpec](http://rspec.info/), [Ruby](https://www.ruby-lang.org).
 
@@ -28,7 +29,7 @@ This framework contains support for...
   for locally installed browsers or drivers
 * Multiple local browsers with automatic driver management
 * Headless execution for those browsers that support it
-* Single-command docker-compose framework to run
+* Single-command docker compose framework to run
   the tests or a supplied command
 * Native through fully-containerized execution
 * Containerized development environment
@@ -38,8 +39,8 @@ This framework contains support for...
 * Basic secrets management using environment variables and
   [GitHub Secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
 
-## To Run the Automated Tests in Docker
-The easiest way to run the tests is with the docker-compose
+## Running
+The easiest way to run the tests is with the docker compose
 framework using the `dockercomposerun` script.
 
 This will pull the latest docker image of this project and run
@@ -47,7 +48,7 @@ the tests against a
 [Selenium Standalone](https://github.com/SeleniumHQ/docker-selenium)
 container.
 
-You can view the running tests, using the included
+You can view the running tests using the included
 Virtual Network Computing (VNC) server.
 
 ### Prerequisites
@@ -59,7 +60,19 @@ Virtual Network Computing (VNC) server.
    LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword!
    ```
 
-#### Optional: Create a `.env` File
+### Running Using the Default Chrome Standalone Container
+By default, the `dockercomposerun` script runs using the
+latest Selenium Standalone Chrome container.
+
+1. Ensure Docker is running
+2. From the project root directory, run the `dockercomposerun`
+   script with the defaults...
+
+   ```
+   LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun
+   ```
+
+### Optional: Creating a `.env` File
 You can create a file named `.env` in the project root directory
 that contains the required environment variables that will
 be used by default by Docker Compose instead of setting them on
@@ -73,18 +86,18 @@ LOGIN_PASSWORD=SuperSecretPassword!
 > name `.env` are ignored by this repository and do not appear in
 > deployment image
 
-### To See the Tests Run Using the VNC Server
+### Seeing the Tests Run
 > Browsers in the containers are not visible in the VNC server
 > when running headless
 
-The Selenium Standalone containers used in the docker-compose
+The Selenium Standalone containers used in the docker compose
 framework have an included VNC server for viewing and
 debugging the tests.
 
 You can use either a VNC client or a web browser to view the tests.
 
 1. Ensure that you are running the Selenium Standalone containers
-   (e.g. in the docker-compose framework)
+   (e.g. in the docker compose framework)
 2. To view the tests... using a web browser, navigate to
    http://localhost:7900/; or to use a VNC server, use
    `vnc://localhost:5900` (On Mac you can simply enter
@@ -94,34 +107,18 @@ You can use either a VNC client or a web browser to view the tests.
 For more information, see the Selenium Standalone Image
 [VNC documentation](https://github.com/SeleniumHQ/docker-selenium#debugging)
 
-### To Run Using the Default Chrome Standalone Container
-1. Ensure Docker is running
-2. From the project root directory, run the `dockercomposerun`
-   script with the defaults...
+### Running Using Other Selenium Standalone Containers
+You can also run the tests using other Selenium Standalone
+containers (such as Firefox and Edge) with the docker compose
+framework.
 
-   ```
-   LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun
-   ```
+For more information, see
+[RUNNING_WITH_OTHER_CONTAINERS.md](docs/RUNNING_WITH_OTHER_CONTAINERS.md).
 
-### To Run Using the Firefox Standalone Container
-1. Ensure Docker is running
-2. From the project root directory, run the `dockercomposerun`
-   script setting the `BROWSER` and `SELENIUM_IMAGE`
-   environment variables to specify Firefox...
-   ```
-   BROWSER=firefox SELENIUM_IMAGE=selenium/standalone-firefox LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun
-   ```
+### Running Interactively (i.e. "Shell In")
+You can run the tests interactively by "shelling in" to the
+test container.
 
-### To Run Using the Edge Standalone Container
-1. Ensure Docker is running
-2. From the project root directory, run the `dockercomposerun`
-   script setting the `BROWSER` and `SELENIUM_IMAGE`
-   environment variables to specify Edge...
-   ```
-   BROWSER=edge SELENIUM_IMAGE=selenium/standalone-edge LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun
-   ```
-
-### To Run the Test Container Interactively (i.e. "Shell In")
 1. Ensure Docker is running
 2. From the project root directory, run the `dockercomposerun`
    script and supply the shell command `sh`...
@@ -135,202 +132,25 @@ For more information, see the Selenium Standalone Image
    exit
    ```
 
-## To Run the Automated Tests Natively
+## Running Natively and Environment Variables
 Assuming that you have a Ruby development environment,
 the tests either can be run directly by the RSpec
 runner or by the supplied Rakefile.
 
-### Prerequisites
-* Ruby 2.7.7
-* To run the tests using a specific browser requires that browser
-be installed
-(e.g. to run the tests in the Chrome Browser requires
-Chrome be installed).
-
-1. Install bundler (if not already installed for your Ruby):
-   ```
-   $ gem install bundler
-   ```
-2. Install gems (from project root):
-   ```
-   $ bundle install
-   ```
-
-### Environment Variables
-
-#### Required Secrets
-`LOGIN_USERNAME=tomsmith`
-`LOGIN_PASSWORD=SuperSecretPassword!`
-
-**These must be set for the login test to pass.**
-
-> These are publicly available values but demonstrate
-> basic secret management
-
-#### Specify Browser
-`BROWSER=`...
-
-> **If the `BROWSER` environment variable is not provided (i.e. set),
-> then the default Capybara `:selenium` (Firefox) browser
-> is used**
-
-**Example:**
-`BROWSER=chrome`
-
-Mostly, this uses a _pass-through_ approach and should support any
-valid `Selenium::WebDriver` browser.
-
-The following browsers were working on Mac at the time of this commit...
-* `chrome` - Google Chrome (requires Chrome)
-* `edge` - Microsoft Edge (requires Edge)
-* `firefox` - Mozilla Firefox (requires Firefox)
-* `safari` - Apple Safari (local only, requires Safari)
-
-> This project uses the
-> [Webdrivers](https://github.com/titusfortner/webdrivers)
-> gem to automatically download and maintain chromedriver, edgedriver, and
-> geckodriver (Firefox).
-
-#### Specify Headless
-`HEADLESS=`...
-
-> **The `HEADLESS` environment variable is ignored if the `BROWSER`
-> environment variable is not provided (i.e. set)**
-
-**Example:**
-`HEADLESS=true`
-
-> The headless specification is implemented as _truthy_ (like Ruby)
-> and ignores case.  Setting `HEADLESS` to any value
-> including empty (i.e. `HEADLESS= `) is interpreted as `true`
-> except for the value `false`.  Thus, setting `HEADLESS=FALSE`
-> will **not** run headless.
-
-#### Specify Remote (Container) URL
-`REMOTE=`...
-
-Specifying a Remote URL creates a remote browser of type
-specified by `BROWSER` at the specified remote URL
-
- **Example:**
-`REMOTE='http://localhost:4444/wd/hub'`
-
-### Examples of Running the Tests
-#### Defaults
-```
-LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! bundle exec rake
-```
-
-> When running the tests locally natively using Rake, the tests are run in
-> parallel **unless** the Safari browser is chosen
-
-```
-LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! bundle exec rspec
-```
-
-#### Local Browsers
-```
-BROWSER=chrome HEADLESS=true LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! bundle exec rake
-```
-
-#### Using the Selenium Standalone Containers
-Like the docker-compose framework, these tests can be run natively
-using the Selenium Standalone containers and the VNC Server
-if you want.
-
-For specifics, see the Selenium Standalone Image
-[documentation](https://github.com/SeleniumHQ/docker-selenium).
-
-1. Run the Selenium Standalone image with standard port and volume mapping...
-   ```
-   docker run -d -p 4444:4444 -p 5900:5900 -p 7900:7900 -v /dev/shm:/dev/shm selenium/standalone-chrome
-   ```
-2. If you want, launch the VNC client in app or browser
-3. Run the tests specifying the remote Selenium container...
-   ```
-   REMOTE='http://localhost:4444/wd/hub' BROWSER=chrome LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! bundle exec rspec
-   ```
+For more information, see [RUNNING_NATIVELY.md](docs/RUNNING_NATIVELY.md).
 
 ## Development
-This project can be developed using the supplied basic, container-based
+This project can be developed using the supplied container-based
 development environment which includes `vim` and `git`.
 
-The development environment container volume mounts your local source
-code to recognize and persist any changes.
-
-By default the development environment container executes the alpine
-`/bin/ash` shell providing a command line interface.
-
-### To Develop Using the Container-Based Development Environment
-The easiest way to run the containerized development environment is with
-the docker-compose framework using the `dockercomposerun` script with the
-`-d` (development environment) option...
-```
-LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -d
-```
-
-This will pull and run the latest development environment image of this
-project along with the Chrome [Selenium Standalone](https://github.com/SeleniumHQ/docker-selenium)
-container.
-
-#### Running Just the Development Environment
-To run the development environment on its own in the docker-compose
-environment **without a Selenium browser**, use the `-n` option for
-no Selenium and the `-d` option for the development environment...
-```
-LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -n -d
-```
-
-#### Building Your Own Development Environment Image
-You can also build and run your own development environment image.
-
-1. Build your development environment image specifying the `devenv` build
-   stage as the target and supplying a name (tag) for the image.
-   ```
-   docker build --no-cache --target devenv -t browsertests-dev .
-   ```
-
-2. Run your development environment image in the docker-compose
-   environment either on its own or with either the Selenium
-   Chrome or Firefox container and specify your development
-   environment image with `BROWSERTESTS_IMAGE`
-   ```
-   BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -n -d
-   ```
-
-#### Specifying the Source Code Location
-To use another directory as the source code for the development
-environment, set the `BROWSERTESTS_SRC` environment variable.
-For example...
-```
-BROWSERTESTS_SRC=${PWD} BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -d
-```
-
-#### Running the Tests, Linting, and Security Scanning
-To run the tests, linting, and security scanning in the development
-environment like CI, use the `run` script.
-
-If you are running interactively (command line) in the development
-environment...
-
-* To run the **tests**...
-  ```
-  ./script/run tests
-  ```
-
-* To run the **linting**...
-  ```
-  ./script/run lint
-  ```
-
-* To run the dependency **security scan**...
-  ```
-  ./script/run secscan
-  ```
+For more information, see [DEVELOPMENT.md](docs/DEVELOPMENT.md).
 
 ## Sources and Additional Information
 These tests use the...
 * SitePrism page object gem: [SitePrism docs](http://www.rubydoc.info/gems/site_prism/index),
-[SitePrism on github](https://github.com/natritmeyer/site_prism)
-* Webdrivers browser driver helper gem: [Webdrivers on github](https://github.com/titusfortner/webdrivers)
-* Selenium Standalone Debug Containers [Selenium HQ on Github](https://github.com/SeleniumHQ/docker-selenium)
+[SitePrism on GitHub](https://github.com/natritmeyer/site_prism)
+* Webdrivers browser driver helper gem: [Webdrivers on GitHub](https://github.com/titusfortner/webdrivers)
+* Selenium Standalone Debug Containers: [Selenium HQ on GitHub](https://github.com/SeleniumHQ/docker-selenium)
+* Rubocop style enforcer and linter: [Rubocop docs](https://rubocop.org/),
+  [Rubocop on GitHub](https://github.com/rubocop/rubocop)
+* bundler-audit dependency static security scanner: [bundler-audit on GitHub](https://github.com/rubysec/bundler-audit)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,76 @@
+## Development of sample-login-capybara-rspec
+This project can be developed using the supplied container-based
+development environment which includes `vim` and `git`.
+
+The development environment container volume mounts your local source
+code to recognize and persist any changes.
+
+By default the development environment container executes the alpine
+`/bin/ash` shell providing a command line interface.
+
+### To Develop Using the Container-Based Development Environment
+The easiest way to run the containerized development environment is with
+the docker-compose framework using the `dockercomposerun` script with the
+`-d` (development environment) option...
+```
+LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -d
+```
+
+This will pull and run the latest development environment image of this
+project along with the Chrome [Selenium Standalone](https://github.com/SeleniumHQ/docker-selenium)
+container.
+
+#### Running Just the Development Environment
+To run the development environment on its own in the docker-compose
+environment **without a Selenium browser**, use the `-n` option for
+no Selenium and the `-d` option for the development environment...
+```
+LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -n -d
+```
+
+#### Building Your Own Development Environment Image
+You can also build and run your own development environment image.
+
+1. Build your development environment image specifying the `devenv` build
+   stage as the target and supplying a name (tag) for the image.
+   ```
+   docker build --no-cache --target devenv -t browsertests-dev .
+   ```
+
+2. Run your development environment image in the docker-compose
+   environment either on its own or with either the Selenium
+   Chrome or Firefox container and specify your development
+   environment image with `BROWSERTESTS_IMAGE`
+   ```
+   BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -n -d
+   ```
+
+#### Specifying the Source Code Location
+To use another directory as the source code for the development
+environment, set the `BROWSERTESTS_SRC` environment variable.
+For example...
+```
+BROWSERTESTS_SRC=${PWD} BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -d
+```
+
+#### Running the Tests, Linting, and Security Scanning
+To run the tests, linting, and security scanning in the development
+environment like CI, use the `run` script.
+
+If you are running interactively (command line) in the development
+environment...
+
+* To run the **tests**...
+  ```
+  ./script/run tests
+  ```
+
+* To run the **linting**...
+  ```
+  ./script/run lint
+  ```
+
+* To run the dependency **security scan**...
+  ```
+  ./script/run secscan
+  ```

--- a/docs/RUNNING_NATIVELY.md
+++ b/docs/RUNNING_NATIVELY.md
@@ -1,0 +1,115 @@
+## Running the Automated Tests Natively and Environment Variables
+Assuming that you have a Ruby development environment,
+the tests either can be run directly by the RSpec
+runner or by the supplied Rakefile.
+
+### Prerequisites
+* Ruby 3.2.1
+* To run the tests using a specific browser requires that browser
+be installed
+(e.g. to run the tests in the Chrome Browser requires
+Chrome be installed).
+
+1. Install bundler (if not already installed for your Ruby):
+   ```
+   $ gem install bundler
+   ```
+2. Install gems (from project root):
+   ```
+   $ bundle install
+   ```
+
+### Environment Variables
+
+#### Required Secrets
+`LOGIN_USERNAME=tomsmith`
+`LOGIN_PASSWORD=SuperSecretPassword!`
+
+**These must be set for the login test to pass.**
+
+> These are publicly available values but demonstrate
+> basic secret management
+
+#### Specify Browser
+`BROWSER=`...
+
+> **If the `BROWSER` environment variable is not provided (i.e. set),
+> then the default Capybara `:selenium` (Firefox) browser
+> is used**
+
+**Example:**
+`BROWSER=chrome`
+
+Mostly, this uses a _pass-through_ approach and should support any
+valid `Selenium::WebDriver` browser.
+
+The following browsers were working on Mac at the time of this commit...
+* `chrome` - Google Chrome (requires Chrome)
+* `edge` - Microsoft Edge (requires Edge)
+* `firefox` - Mozilla Firefox (requires Firefox)
+* `safari` - Apple Safari (local only, requires Safari)
+
+> This project uses the
+> [Webdrivers](https://github.com/titusfortner/webdrivers)
+> gem to automatically download and maintain chromedriver, edgedriver, and
+> geckodriver (Firefox).
+
+#### Specify Headless
+`HEADLESS=`...
+
+> **The `HEADLESS` environment variable is ignored if the `BROWSER`
+> environment variable is not provided (i.e. set)**
+
+**Example:**
+`HEADLESS=true`
+
+> The headless specification is implemented as _truthy_ (like Ruby)
+> and ignores case.  Setting `HEADLESS` to any value
+> including empty (i.e. `HEADLESS= `) is interpreted as `true`
+> except for the value `false`.  Thus, setting `HEADLESS=FALSE`
+> will **not** run headless.
+
+#### Specify Remote (Container) URL
+`REMOTE=`...
+
+Specifying a Remote URL creates a remote browser of type
+specified by `BROWSER` at the specified remote URL
+
+ **Example:**
+`REMOTE='http://localhost:4444/wd/hub'`
+
+### Examples of Running the Tests
+#### Defaults
+```
+LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! bundle exec rake
+```
+
+> When running the tests locally natively using Rake, the tests are run in
+> parallel **unless** the Safari browser is chosen
+
+```
+LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! bundle exec rspec
+```
+
+#### Local Browsers
+```
+BROWSER=chrome HEADLESS=true LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! bundle exec rake
+```
+
+#### Using the Selenium Standalone Containers
+Like the docker-compose framework, these tests can be run natively
+using the Selenium Standalone containers and the VNC Server
+if you want.
+
+For specifics, see the Selenium Standalone Image
+[documentation](https://github.com/SeleniumHQ/docker-selenium).
+
+1. Run the Selenium Standalone image with standard port and volume mapping...
+   ```
+   docker run -d -p 4444:4444 -p 5900:5900 -p 7900:7900 -v /dev/shm:/dev/shm selenium/standalone-chrome
+   ```
+2. If you want, launch the VNC client in app or browser
+3. Run the tests specifying the remote Selenium container...
+   ```
+   REMOTE='http://localhost:4444/wd/hub' BROWSER=chrome LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! bundle exec rspec
+   ```

--- a/docs/RUNNING_WITH_OTHER_CONTAINERS.md
+++ b/docs/RUNNING_WITH_OTHER_CONTAINERS.md
@@ -1,0 +1,22 @@
+## Running Using Other Selenium Standalone Containers
+You can also run the tests using other Selenium Standalone
+containers (such as Firefox and Edge) with the docker compose
+framework.
+
+### To Run Using the Firefox Standalone Container
+1. Ensure Docker is running
+2. From the project root directory, run the `dockercomposerun`
+   script setting the `BROWSER` and `SELENIUM_IMAGE`
+   environment variables to specify Firefox...
+   ```
+   BROWSER=firefox SELENIUM_IMAGE=selenium/standalone-firefox LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun
+   ```
+
+### To Run Using the Edge Standalone Container
+1. Ensure Docker is running
+2. From the project root directory, run the `dockercomposerun`
+   script setting the `BROWSER` and `SELENIUM_IMAGE`
+   environment variables to specify Edge...
+   ```
+   BROWSER=edge SELENIUM_IMAGE=selenium/standalone-edge LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun
+   ```


### PR DESCRIPTION
# What
This documentation only changeset shortens the README by moving details into separate documents in the new `docs` directory. 

# Why
Hopefully this should make the README more concise without overloading the reader with TMI.

# Change Impact Analysis and Testing
- [x] Readme and new documents manually inspected as rendered by GitHub
