### PR TITLE
Deprecate the webdrivers Gem for the Selenium Manager facility in selenium-webdrivers Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,3 @@ gem 'rubocop-rake', require: false
 gem 'rubocop-rspec', require: false
 gem 'selenium-webdriver'
 gem 'site_prism'
-gem 'webdrivers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
-    public_suffix (5.0.1)
+    public_suffix (5.0.3)
     racc (1.7.1)
     rack (3.0.8)
     rack-test (2.1.0)
@@ -47,13 +47,13 @@ GEM
     rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.5)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
     rspec-support (3.12.1)
-    rubocop (1.54.1)
+    rubocop (1.55.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -61,7 +61,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.0, < 2.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.29.0)
@@ -86,13 +86,9 @@ GEM
       addressable (~> 2.8)
       capybara (~> 3.27)
       site_prism-all_there (~> 2.0)
-    site_prism-all_there (2.0.1)
+    site_prism-all_there (2.0.2)
     thor (1.2.2)
     unicode-display_width (2.4.2)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     websocket (1.2.9)
     xpath (3.2.0)
       nokogiri (~> 1.8)
@@ -112,7 +108,6 @@ DEPENDENCIES
   rubocop-rspec
   selenium-webdriver
   site_prism
-  webdrivers
 
 BUNDLED WITH
    2.4.15

--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ For more information, see [DEVELOPMENT.md](docs/DEVELOPMENT.md).
 These tests use the...
 * SitePrism page object gem: [SitePrism docs](http://www.rubydoc.info/gems/site_prism/index),
 [SitePrism on GitHub](https://github.com/natritmeyer/site_prism)
-* Webdrivers browser driver helper gem: [Webdrivers on GitHub](https://github.com/titusfortner/webdrivers)
 * Selenium Standalone Debug Containers: [Selenium HQ on GitHub](https://github.com/SeleniumHQ/docker-selenium)
 * Rubocop style enforcer and linter: [Rubocop docs](https://rubocop.org/),
   [Rubocop on GitHub](https://github.com/rubocop/rubocop)

--- a/docs/RUNNING_NATIVELY.md
+++ b/docs/RUNNING_NATIVELY.md
@@ -50,9 +50,10 @@ The following browsers were working on Mac at the time of this commit...
 * `safari` - Apple Safari (local only, requires Safari)
 
 > This project uses the
-> [Webdrivers](https://github.com/titusfortner/webdrivers)
-> gem to automatically download and maintain chromedriver, edgedriver, and
-> geckodriver (Firefox).
+> [Selenium Manager](https://www.selenium.dev/blog/2022/introducing-selenium-manager/)
+> facility built into the `selenium-webdriver` gem to automatically
+> download and maintain chromedriver, edgedriver,
+> and geckodriver (Firefox).
 
 #### Specify Headless
 `HEADLESS=`...

--- a/spec/support/capybara_browser.rb
+++ b/spec/support/capybara_browser.rb
@@ -3,7 +3,6 @@
 require 'capybara'
 require 'capybara/rspec'
 require 'selenium/webdriver'
-require 'webdrivers'
 
 ### METHODS ###
 def create_browser(browser:, url:)


### PR DESCRIPTION
# What
This changeset deprecates the use of the [`webdrivers`](https://github.com/titusfortner/webdrivers) gem for native browser driver (e.g. chromedriver, geckodriver, edgedriver) installation and management.  This browser driver installation and management is now built into the `selenium-webdriver` gem which is already being used by this project.

This changeset also updates any gems.

> 👀 For more information see the new [Selenium Manager](https://www.selenium.dev/blog/2022/introducing-selenium-manager/). 

# Why
With browser driver management now built into `selenium-webdriver`, the `webdrivers` gem is not as actively maintained.

# Change Impact Analysis and Testing

- [x] CI checks code standards and no regressions in behavior
- [x] Manually ran supported browsers natively (Chrome 115)