### PR TITLE
Add Multi-Architecture Image Support (`linux/arm64`)

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -9,7 +9,7 @@ on:
 #  Raw Branch Name: ${{ github.head_ref }}
 #  <commit-sha>: ${{ github.event.pull_request.head.sha }}
 
-# Produced images...
+# Produced multi-architecture (linux/amd64,linux/arm64) images...
 #  1. (Always) Unvetted Image: <owner/repository>_<normalized-branch>_unvetted:<commit-sha>
 #  2. (Always) Dev Environment Image: <owner/repository>_<normalized-branch>_dev:<commit-sha>
 #  3. (If vetted) Vetted_image: <owner/repository>_<normalized-branch>:<commit-sha>
@@ -22,28 +22,30 @@ jobs:
       raw_name: ${{ github.head_ref }}
 
   # Build and Push Images
-  build-and-push-branch-devenv:
+  buildx-and-push-branch-devenv:
     needs: [pr-norm-branch]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/build_push_image.yml@main
+    uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@main
     with:
       image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
+      platforms: "linux/amd64,linux/arm64"
       buildopts: --target devenv
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-  build-and-push-branch-unvetted:
+  buildx-and-push-branch-unvetted:
     needs: [pr-norm-branch]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/build_push_image.yml@main
+    uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@main
     with:
       image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
+      platforms: "linux/amd64,linux/arm64"
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   # Vet Deploy Image
   vet-code-standards:
-    needs: [pr-norm-branch, build-and-push-branch-devenv]
+    needs: [pr-norm-branch, buildx-and-push-branch-devenv]
     runs-on: ubuntu-latest
     env:
       DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
@@ -53,7 +55,7 @@ jobs:
         run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -n -d ./script/run lint"
 
   vet-dependency-security:
-    needs: [pr-norm-branch, build-and-push-branch-devenv]
+    needs: [pr-norm-branch, buildx-and-push-branch-devenv]
     runs-on: ubuntu-latest
     env:
       DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
@@ -63,7 +65,7 @@ jobs:
         run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -n -d ./script/run secscan"
 
   vet-deploy-e2e-tests-matrix:
-    needs: [pr-norm-branch, build-and-push-branch-unvetted]
+    needs: [pr-norm-branch, buildx-and-push-branch-unvetted]
     strategy:
       fail-fast: false
       matrix:
@@ -80,26 +82,24 @@ jobs:
       - name: dockercomposerun unvetted image
         run: "BROWSERTESTS_IMAGE=${UNVETTED_IMAGE} ./script/dockercomposerun -c"
 
-# Push (IF) Vetted Deploy Image
-  push-branch-vetted-deploy-image:
+# Copy (IF) Vetted Deploy Image
+  copy-branch-vetted-deploy-image:
     needs:
       - vet-code-standards
       - vet-dependency-security
       - vet-deploy-e2e-tests-matrix
       - pr-norm-branch
-    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@main
     with:
-      # Pull unvetted branch image
-      pull_as: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
-      # Push Vetted Image
-      push_as: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}:${{ github.event.pull_request.head.sha }}
+      source_image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
+      target_image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}:${{ github.event.pull_request.head.sha }}
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   # Vet Dev Environment Image
   vet-devenv-e2e-tests-matrix:
-    needs: [pr-norm-branch, build-and-push-branch-devenv]
+    needs: [pr-norm-branch, buildx-and-push-branch-devenv]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/on_push_to_main_promote_to_prod.yml
+++ b/.github/workflows/on_push_to_main_promote_to_prod.yml
@@ -32,19 +32,17 @@ jobs:
 
   promote-branch-last-commit-to-prod:
     needs: [branch-and-last-commit, push-norm-branch]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@main
     with:
-      # Pull last (vetted) branch image
-      pull_as: ${{ github.repository }}_${{ needs.push-norm-branch.outputs.name }}:${{ needs.branch-and-last-commit.outputs.commit }}
-      # Push prod Image
-      push_as: ${{ github.repository }}:${{ needs.branch-and-last-commit.outputs.commit }}
+      source_image: ${{ github.repository }}_${{ needs.push-norm-branch.outputs.name }}:${{ needs.branch-and-last-commit.outputs.commit }}
+      target_image: ${{ github.repository }}:${{ needs.branch-and-last-commit.outputs.commit }}
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   promote-branch-last-commit-to-prod-latest:
     needs: [branch-and-last-commit, promote-branch-last-commit-to-prod]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_latest_image.yml@main
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@main
     with:
       image_name: ${{ github.repository }}
       image_tag: ${{ needs.branch-and-last-commit.outputs.commit }}
@@ -54,19 +52,17 @@ jobs:
 
   promote-branch-last-commit-devenv:
     needs: [branch-and-last-commit, push-norm-branch]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@main
     with:
-      # Pull last branch devenv image
-      pull_as: ${{ github.repository }}_${{ needs.push-norm-branch.outputs.name }}_dev:${{ needs.branch-and-last-commit.outputs.commit }}
-      # Push prod devenv image
-      push_as: ${{ github.repository }}-dev:${{ needs.branch-and-last-commit.outputs.commit }}
+      source_image: ${{ github.repository }}_${{ needs.push-norm-branch.outputs.name }}_dev:${{ needs.branch-and-last-commit.outputs.commit }}
+      target_image: ${{ github.repository }}-dev:${{ needs.branch-and-last-commit.outputs.commit }}
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   promote-branch-last-commit-devenv-to-latest:
     needs: [branch-and-last-commit, promote-branch-last-commit-devenv]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_latest_image.yml@main
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@main
     with:
       image_name: ${{ github.repository }}-dev
       image_tag: ${{ needs.branch-and-last-commit.outputs.commit }}

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ This framework contains support for...
 The easiest way to run the tests is with the docker compose
 framework using the `dockercomposerun` script.
 
+> :apple: The images built for this project are multi-platform
+> images that support both `linux/amd64` (e.g. x86) and
+> `linux/arm64` (i.e. Apple Silicon)
+
 This will pull the latest docker image of this project and run
 the tests against a
 [Selenium Standalone](https://github.com/SeleniumHQ/docker-selenium)
@@ -71,6 +75,10 @@ latest Selenium Standalone Chrome container.
    ```
    LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun
    ```
+
+> :apple: Apple Silicon Macs will actually run against the
+> [Seleniarm Standalone](https://github.com/seleniumhq-community/docker-seleniarm)
+> container
 
 ### Optional: Creating a `.env` File
 You can create a file named `.env` in the project root directory

--- a/docker-compose.seleniarm.yml
+++ b/docker-compose.seleniarm.yml
@@ -1,0 +1,4 @@
+version: '3.4'
+services:
+  seleniumbrowser:
+    image: ${SELENIUM_IMAGE:-seleniarm/standalone-chromium:latest}

--- a/script/dockercomposerun
+++ b/script/dockercomposerun
@@ -69,6 +69,11 @@ docker_compose_command='docker-compose -f docker-compose.yml '
 if [ -z ${noselenium} ]; then
   echo "...Adding Selenium Browser to Environment"
   docker_compose_command="${docker_compose_command} -f docker-compose.selenium.yml "
+
+  if [[ `uname -m` == "arm64" ]]; then
+    echo "...Apple Silicon Detected adding Seleniarm Browser Override to Environment"
+    docker_compose_command="${docker_compose_command} -f docker-compose.seleniarm.yml "
+  fi
 fi
 
 if [ ! -z ${ci} ]; then


### PR DESCRIPTION
# What
This changeset adds support for Apple Silicon by creating `linux/arm64` images in CI in addition to the `linux/amd64` image.  This was actually already happening since the last PR brianjbayer/SampleCSharpXunitSelenium#11.

Specifically...
* Updates CI workflows to use the multi-architecture actions to build the `linux/arm64` and `linux/amd64` images
* Adds (automatic) support for [Seleniarm browser](https://github.com/seleniumhq-community/docker-seleniarm) image for Apple Silicon
* Updates readme about Seleniarm browser

# Why
This makes life easier for Apple Silicon based development and operations.

# Change Impact Analysis and Testing

- [x] PR CI Checks vet PR actions
  - [x] Verify `linux/arm64` and `linux/amd64` images in Docker Hub
- [ ] Merge checks will only vet those changes to main branch on merge 😦 

- [x] Verify Seleniarm support on Apple Silicon

- [x] Verify `dockercompose` framework and branch images run locally
  - [x] Apple Silicon
    - [x] Dev image
    - [x] Deploy Image
  - [x] x86 (MBP)
    - [x] Dev image
    - [x] Deploy Image

- [x] Verify can run locally natively
  - [x] x86 (MBP)
  - [x] Apple Silicon

- [x] README changes inspected on branch
