### PR TITLE
Move to Using a Debian-based Base Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,28 +3,46 @@
 #-----------------------------------
 
 #--- Base Image ---
-ARG BASE_IMAGE=ruby:3.2.2-alpine
-FROM ${BASE_IMAGE} AS ruby-alpine
+ARG BASE_IMAGE=ruby:3.2.2-slim-bullseye
+FROM ${BASE_IMAGE} AS ruby-base
+
+# Install packages common to builder (dev) and deploy
+ARG BASE_PACKAGES='curl'
+
+RUN apt-get update \
+  && apt-get -y dist-upgrade \
+  && apt-get -y install ${BASE_PACKAGES} \
+  && rm -rf /var/lib/apt/lists/*
 
 #--- Builder Stage ---
-FROM ruby-alpine AS builder
-
-# Alpine needs build-base for building native extensions
-ARG BUILD_PACKAGES='build-dependencies build-base'
+FROM ruby-base AS builder
 
 # Use the same version of Bundler in the Gemfile.lock
 ARG BUNDLER_VERSION=2.4.21
 ENV BUNDLER_VERSION=${BUNDLER_VERSION}
 
-RUN apk --update add --virtual ${BUILD_PACKAGES} \
+# Install base build packages
+ARG BASE_BUILD_PACKAGES='build-essential'
+
+# Assumes debian based
+RUN apt-get update \
+  && apt-get -y dist-upgrade \
+  && apt-get -y install ${BASE_BUILD_PACKAGES} \
+  && rm -rf /var/lib/apt/lists/* \
   # Update gem command to latest
   && gem update --system \
+  # Install bundler
   && gem install bundler:${BUNDLER_VERSION}
 
 # Install the Ruby dependencies (defined in the Gemfile/Gemfile.lock)
 WORKDIR /app
 COPY Gemfile Gemfile.lock ./
-RUN bundle install
+
+# Add support for multiple platforms
+RUN bundle lock --add-platform ruby \
+  && bundle lock --add-platform x86_64-linux \
+  && bundle lock --add-platform aarch64-linux \
+  && bundle install
 
 #--- Dev Environment ---
 # ASSUME source is docker volumed into the image
@@ -32,18 +50,34 @@ FROM builder AS devenv
 
 # For Dev Env, add git and vim at least
 ARG DEVENV_PACKAGES='git vim'
-RUN apk --update add ${DEVENV_PACKAGES}
+
+ARG BUNDLER_PATH=/usr/local/bundle
+
+# Install dev environment specific build packages
+# Assumes debian based
+RUN apt-get update \
+  && apt-get -y dist-upgrade \
+  && apt-get -y install ${DEVENV_PACKAGES} \
+  && rm -rf /var/lib/apt/lists/* \
+  # Install app dependencies
+  && bundle install \
+    # Remove unneeded files (cached *.gem, *.o, *.c)
+    && rm -rf ${BUNDLER_PATH}/cache/*.gem \
+    && find ${BUNDLER_PATH}/gems/ -name "*.c" -delete \
+    && find ${BUNDLER_PATH}/gems/ -name "*.o" -delete
+
 
 # Start devenv in (command line) shell
-CMD sh
+# Assumes debian based
+CMD bash
 
 #--- Deploy Stage ---
-FROM ruby-alpine AS deploy
+FROM ruby-base AS deploy
 
 # Throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1 \
-# Add a user so not running as root
-  && adduser -D deployer
+  # Add a user so not running as root - Assumes debian based
+  && adduser --disabled-password --gecos '' deployer
 
 # Run as deployer USER instead of as root
 USER deployer

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,10 @@ GEM
     language_server-protocol (3.17.0.3)
     matrix (0.4.2)
     mini_mime (1.1.5)
+    nokogiri (1.15.4-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.15.4-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     parallel (1.23.0)
@@ -94,7 +98,9 @@ GEM
       nokogiri (~> 1.8)
 
 PLATFORMS
-  x86_64-linux-musl
+  aarch64-linux
+  arm64-darwin-23
+  x86_64-linux
 
 DEPENDENCIES
   bundler-audit

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -5,8 +5,8 @@ development environment which includes `vim` and `git`.
 The development environment container volume mounts your local source
 code to recognize and persist any changes.
 
-By default the development environment container executes the alpine
-`/bin/ash` shell providing a command line interface.
+By default the development environment container executes the debian
+`/bin/bash` shell providing a command line interface.
 
 ### To Develop Using the Container-Based Development Environment
 The easiest way to run the containerized development environment is with

--- a/script/run
+++ b/script/run
@@ -35,12 +35,14 @@ run_and_exit_return_code () {
 }
 
 wait_until_ready_if_remote_browser() {
-# Assumes wget (Alpine)
   if [ ! -z "${REMOTE_STATUS}" ];
   then
+    # This assumes curl and will not operate correctly without it
+    curl --version || (echo "ERROR: curl command is not found (127)" ; exit 127)
+
     COUNTER=0
     echo "Waiting for remote browser at [${REMOTE_STATUS}] to become available"
-    until wget --spider -q "${REMOTE_STATUS}" &>/dev/null; do
+    until curl -fsSL "${REMOTE_STATUS}" >/dev/null 2>&1; do
       printf "."
       sleep 1
       COUNTER=$((COUNTER + 1))


### PR DESCRIPTION

# What
This changeset moves this projects' image to be Debian linux based instead of Alpine (Musl) based.  As a result `curl` is now a dependency and installed in the deploy and dev images.  Finally support for multiple platforms is added to the `Dockerfile`/`Gemfile.lock`.

# Why
Although Alpine served its purpose, it makes support for multiple (e.g. x86/amd and arm64) platforms difficult especially with container-based artifacts.

# Change Impact Analysis and Testing
These changes are primarily related to the deploy images.

- [ ] CI Builds Images and Checks are successful
- [ ] Run dockercompose environment locally
  - [ ] x86
    - [ ] dev environment 
    - [ ] deploy
  - [ ] Apple Silicon
    - [ ] dev environment 
    - [ ] deploy
- [ ] Run native 