### PR TITLE
Add Global Configuration and a BASE_URL Environment Variable for the Test Pages

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -75,6 +75,7 @@ jobs:
       UNVETTED_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
       BROWSER: ${{ matrix.browser }}
       SELENIUM_IMAGE: selenium/standalone-${{ matrix.browser }}:latest
+      BASE_URL: "https://the-internet.herokuapp.com"
       LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
       LOGIN_PASSWORD: ${{ secrets.LOGIN_PASSWORD }}
     steps:
@@ -109,6 +110,7 @@ jobs:
       DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
       BROWSER: ${{ matrix.browser }}
       SELENIUM_IMAGE: selenium/standalone-${{ matrix.browser }}:latest
+      BASE_URL: "https://the-internet.herokuapp.com"
       LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
       LOGIN_PASSWORD: ${{ secrets.LOGIN_PASSWORD }}
     steps:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ This framework contains support for...
 * Basic secrets management using environment variables and
   [GitHub Secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
 
+## Prerequisites
+Before being able to run this project, you must follow the requirements
+in the [PREREQUISITES.md](docs/PREREQUISITES.md)
+
 ## Running
 The easiest way to run the tests is with the docker compose
 framework using the `dockercomposerun` script.
@@ -54,45 +58,6 @@ container.
 
 You can view the running tests using the included
 Virtual Network Computing (VNC) server.
-
-### Prerequisites
-1. You must have Docker installed and running on your local machine.
-2. You must specify the login credentials (i.e. secrets) used in the
-   test with the `LOGIN_USERNAME` and `LOGIN_PASSWORD` environment
-   variables...
-   ```
-   LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword!
-   ```
-
-### Running Using the Default Chrome Standalone Container
-By default, the `dockercomposerun` script runs using the
-latest Selenium Standalone Chrome container.
-
-1. Ensure Docker is running
-2. From the project root directory, run the `dockercomposerun`
-   script with the defaults...
-
-   ```
-   LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun
-   ```
-
-> :apple: Apple Silicon Macs will actually run against the
-> [Seleniarm Standalone](https://github.com/seleniumhq-community/docker-seleniarm)
-> container
-
-### Optional: Creating a `.env` File
-You can create a file named `.env` in the project root directory
-that contains the required environment variables that will
-be used by default by Docker Compose instead of setting them on
-the command line...
-```
-LOGIN_USERNAME=tomsmith
-LOGIN_PASSWORD=SuperSecretPassword!
-```
-
-> Note that files in the project root directory starting with the
-> name `.env` are ignored by this repository and do not appear in
-> deployment image
 
 ### Seeing the Tests Run
 > Browsers in the containers are not visible in the VNC server
@@ -115,6 +80,22 @@ You can use either a VNC client or a web browser to view the tests.
 For more information, see the Selenium Standalone Image
 [VNC documentation](https://github.com/SeleniumHQ/docker-selenium#debugging)
 
+### Running Using the Default Chrome Standalone Container
+By default, the `dockercomposerun` script runs using the
+latest Selenium Standalone Chrome container.
+
+1. Ensure Docker is running
+2. From the project root directory, run the `dockercomposerun`
+   script with the defaults...
+
+   ```
+   ./script/dockercomposerun
+   ```
+
+> :apple: Apple Silicon Macs will actually run against the
+> [Seleniarm Standalone](https://github.com/seleniumhq-community/docker-seleniarm)
+> container
+
 ### Running Using Other Selenium Standalone Containers
 You can also run the tests using other Selenium Standalone
 containers (such as Firefox and Edge) with the docker compose
@@ -131,7 +112,7 @@ test container.
 2. From the project root directory, run the `dockercomposerun`
    script and supply the shell command `sh`...
    ```
-   LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun sh
+   ./script/dockercomposerun sh
    ```
 3. Run desired commands in the container
    (e.g. `bundle exec rake`)
@@ -157,7 +138,10 @@ For more information, see [DEVELOPMENT.md](docs/DEVELOPMENT.md).
 These tests use the...
 * SitePrism page object gem: [SitePrism docs](http://www.rubydoc.info/gems/site_prism/index),
 [SitePrism on GitHub](https://github.com/natritmeyer/site_prism)
-* Selenium Standalone Debug Containers: [Selenium HQ on GitHub](https://github.com/SeleniumHQ/docker-selenium)
+* Selenium Standalone Containers: [Selenium HQ on GitHub](https://github.com/SeleniumHQ/docker-selenium),
+  [Selenium on Docker Hub](https://hub.docker.com/u/selenium)
+* Seleniarm Standalone Containers [Seleniarm HQ on GitHub](https://github.com/seleniumhq-community/docker-seleniarm),
+  [Seleniarm on Docker Hub](https://hub.docker.com/u/seleniarm)
 * Rubocop style enforcer and linter: [Rubocop docs](https://rubocop.org/),
   [Rubocop on GitHub](https://github.com/rubocop/rubocop)
 * bundler-audit dependency static security scanner: [bundler-audit on GitHub](https://github.com/rubysec/bundler-audit)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,6 @@ services:
     image: brianjbayer/sample-login-capybara-rspec:${BROWSERTESTS_TAG:-latest}
     container_name: ${BROWSERTESTS_HOSTNAME:-browsertests}
     environment:
+      - BASE_URL
       - LOGIN_USERNAME
       - LOGIN_PASSWORD

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -8,12 +8,16 @@ code to recognize and persist any changes.
 By default the development environment container executes the debian
 `/bin/bash` shell providing a command line interface.
 
+### Prerequisites
+Before being able to run this project, you must follow the requirements
+in the [PREREQUISITES.md](PREREQUISITES.md)
+
 ### To Develop Using the Container-Based Development Environment
 The easiest way to run the containerized development environment is with
 the docker-compose framework using the `dockercomposerun` script with the
 `-d` (development environment) option...
 ```
-LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -d
+./script/dockercomposerun -d
 ```
 
 This will pull and run the latest development environment image of this
@@ -25,7 +29,7 @@ To run the development environment on its own in the docker-compose
 environment **without a Selenium browser**, use the `-n` option for
 no Selenium and the `-d` option for the development environment...
 ```
-LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -n -d
+./script/dockercomposerun -n -d
 ```
 
 #### Building Your Own Development Environment Image
@@ -38,11 +42,11 @@ You can also build and run your own development environment image.
    ```
 
 2. Run your development environment image in the docker-compose
-   environment either on its own or with either the Selenium
-   Chrome or Firefox container and specify your development
+   environment either on its own or with the Selenium Chrome
+   (or other browser containers) and specify your development
    environment image with `BROWSERTESTS_IMAGE`
    ```
-   BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -n -d
+   BROWSERTESTS_IMAGE=browsertests-dev ./script/dockercomposerun -n -d
    ```
 
 #### Specifying the Source Code Location
@@ -50,7 +54,7 @@ To use another directory as the source code for the development
 environment, set the `BROWSERTESTS_SRC` environment variable.
 For example...
 ```
-BROWSERTESTS_SRC=${PWD} BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -d
+BROWSERTESTS_SRC=${PWD} BROWSERTESTS_IMAGE=browsertests-dev ./script/dockercomposerun -d
 ```
 
 #### Running the Tests, Linting, and Security Scanning

--- a/docs/PREREQUISITES.md
+++ b/docs/PREREQUISITES.md
@@ -1,0 +1,41 @@
+## Prerequisites
+
+In order to run this project...
+
+1. You must have Docker installed and running on your host
+   machine to run the project using the docker compose framework
+
+2. To run the tests, you must set the required environment
+   variable and value...
+   ```
+   BASE_URL='https://the-internet.herokuapp.com'
+   ```
+
+3. To run the tests, you must set the required secret
+   environment variable and value...
+   ```
+   LOGIN_USERNAME=tomsmith
+   ```
+
+4. To run the tests, you must set the required secret
+   environment variable and value...
+   ```
+   LOGIN_PASSWORD=SuperSecretPassword!
+   ```
+
+> These are publicly available values but demonstrate
+> basic secret management
+
+### Optional: Creating a `.env` File
+You can create a file named `.env` in the project root directory
+that contains the required environment variables that will
+be used by default by docker compose instead of setting them on
+the command line...
+
+> :no_entry_sign: However your `.env` file will not be used when running natively
+
+```
+BASE_URL='https://the-internet.herokuapp.com'
+LOGIN_USERNAME=tomsmith
+LOGIN_PASSWORD=SuperSecretPassword!
+```

--- a/docs/RUNNING_NATIVELY.md
+++ b/docs/RUNNING_NATIVELY.md
@@ -4,7 +4,7 @@ the tests either can be run directly by the RSpec
 runner or by the supplied Rakefile.
 
 ### Prerequisites
-* Ruby 3.2.1
+* Ruby 3.2.2
 * To run the tests using a specific browser requires that browser
 be installed
 (e.g. to run the tests in the Chrome Browser requires
@@ -20,15 +20,9 @@ Chrome be installed).
    ```
 
 ### Environment Variables
-
-#### Required Secrets
-`LOGIN_USERNAME=tomsmith`
-`LOGIN_PASSWORD=SuperSecretPassword!`
-
-**These must be set for the login test to pass.**
-
-> These are publicly available values but demonstrate
-> basic secret management
+#### Required Environment Variables and Secrets
+For the required secrets and other environment variables,
+see the [PREREQUISITES.md](PREREQUISITES.md)
 
 #### Specify Browser
 `BROWSER=`...
@@ -82,19 +76,19 @@ specified by `BROWSER` at the specified remote URL
 ### Examples of Running the Tests
 #### Defaults
 ```
-LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! bundle exec rake
+bundle exec rake
 ```
 
 > When running the tests locally natively using Rake, the tests are run in
 > parallel **unless** the Safari browser is chosen
 
 ```
-LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! bundle exec rspec
+bundle exec rspec
 ```
 
 #### Local Browsers
 ```
-BROWSER=chrome HEADLESS=true LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! bundle exec rake
+BROWSER=chrome HEADLESS=true bundle exec rake
 ```
 
 #### Using the Selenium Standalone Containers
@@ -112,5 +106,5 @@ For specifics, see the Selenium Standalone Image
 2. If you want, launch the VNC client in app or browser
 3. Run the tests specifying the remote Selenium container...
    ```
-   REMOTE='http://localhost:4444/wd/hub' BROWSER=chrome LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! bundle exec rspec
+   REMOTE='http://localhost:4444/wd/hub' BROWSER=chrome bundle exec rspec
    ```

--- a/docs/RUNNING_WITH_OTHER_CONTAINERS.md
+++ b/docs/RUNNING_WITH_OTHER_CONTAINERS.md
@@ -3,13 +3,24 @@ You can also run the tests using other Selenium Standalone
 containers (such as Firefox and Edge) with the docker compose
 framework.
 
+### Prerequisites
+Before being able to run this project, you must follow the requirements
+in the [PREREQUISITES.md](PREREQUISITES.md)
+
 ### To Run Using the Firefox Standalone Container
 1. Ensure Docker is running
 2. From the project root directory, run the `dockercomposerun`
    script setting the `BROWSER` and `SELENIUM_IMAGE`
    environment variables to specify Firefox...
+
+   **For Intel/x86/amd64 run...**
    ```
-   BROWSER=firefox SELENIUM_IMAGE=selenium/standalone-firefox LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun
+   BROWSER=firefox SELENIUM_IMAGE=selenium/standalone-firefox ./script/dockercomposerun
+   ```
+
+   **:apple: For Apple Silicon/arm64 run...**
+   ```
+   BROWSER=firefox SELENIUM_IMAGE=seleniarm/standalone-firefox ./script/dockercomposerun
    ```
 
 ### To Run Using the Edge Standalone Container
@@ -17,6 +28,13 @@ framework.
 2. From the project root directory, run the `dockercomposerun`
    script setting the `BROWSER` and `SELENIUM_IMAGE`
    environment variables to specify Edge...
+
+   **For Intel/x86/amd64 run...**
    ```
-   BROWSER=edge SELENIUM_IMAGE=selenium/standalone-edge LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun
+   BROWSER=edge SELENIUM_IMAGE=selenium/standalone-edge ./script/dockercomposerun
    ```
+
+   **:apple: For Apple Silicon/arm64...**
+
+   There is no Seleniarm Edge images as it actually runs chromium, which
+   is what both Chrome and Edge are based upon

--- a/spec/features/site_prism/login_page.rb
+++ b/spec/features/site_prism/login_page.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 class LoginPage < SitePrism::Page
-  set_url 'http://the-internet.herokuapp.com/login'
+  set_url "#{page_base_url}/login"
 
   element :username_input, 'input[id="username"]'
   element :password_input, 'input[id="password"]'
   element :submit_button, 'button[type="submit"]'
 
   def login_with_valid_credentials
-    username_input.set ENV.fetch('LOGIN_USERNAME')
-    password_input.set ENV.fetch('LOGIN_PASSWORD')
+    username_input.set valid_login_username
+    password_input.set valid_login_password
     submit_button.click
   end
 end

--- a/spec/features/site_prism/secure_area_page.rb
+++ b/spec/features/site_prism/secure_area_page.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class SecureAreaPage < SitePrism::Page
-  set_url 'http://the-internet.herokuapp.com/secure'
+  set_url "#{page_base_url}/secure"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,10 @@ require 'capybara'
 require 'capybara/rspec'
 require 'selenium-webdriver'
 require 'site_prism'
+
 require 'support/capybara_browser'
+require 'support/config'
+require 'support/page_helpers'
 
 ## Configure Test Framework ##
 RSpec.configure do |config|

--- a/spec/support/capybara_browser.rb
+++ b/spec/support/capybara_browser.rb
@@ -4,12 +4,14 @@ require 'capybara'
 require 'capybara/rspec'
 require 'selenium/webdriver'
 
+require_relative 'config'
+
 ### METHODS ###
-def create_browser(browser:, url:)
+# Main method that determines and creates the Capybara-driven browser
+def create_browser
   # default is local default capybara browser
   return (Capybara.default_driver = :selenium) unless browser || url
 
-  browser = browser.to_sym
   options = browser_options(browser)
 
   Capybara.register_driver :capy_browser do |app|
@@ -25,15 +27,21 @@ def browser_options(browser)
   browser = browser.to_s.gsub(/\W/, '').capitalize
   # e.g. Selenium::WebDriver::Chrome::Options.new
   options = Selenium::WebDriver.const_get(browser).const_get('Options').new
-  options.add_argument('--headless') if headless_specified?
+  options.add_argument('--headless') if headless?
   options
 end
 
-def headless_specified?
-  headless = ENV.fetch('HEADLESS', false)
-  headless.to_s.downcase != 'false'
+def browser
+  Config::Capybara.browser&.to_sym
+end
+
+def url
+  Config::Capybara.remote_browser_url
+end
+
+def headless?
+  Config::Capybara.headless?
 end
 
 ### MAIN ###
-create_browser(browser: ENV.fetch('BROWSER', nil),
-               url: ENV.fetch('REMOTE', nil))
+create_browser

--- a/spec/support/config.rb
+++ b/spec/support/config.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Config
+  # (Required) Configuration for PageObject pages
+  module Pages
+    def self.page_base_url
+      ENV.fetch('BASE_URL')
+    end
+
+    def self.valid_login_username
+      ENV.fetch('LOGIN_USERNAME')
+    end
+
+    def self.valid_login_password
+      ENV.fetch('LOGIN_PASSWORD')
+    end
+  end
+end
+
+module Config
+  # Configuration for Capybara-driven browser
+  module Capybara
+    def self.browser
+      ENV.fetch('BROWSER', nil)
+    end
+
+    def self.remote_browser_url
+      ENV.fetch('REMOTE', nil)
+    end
+
+    def self.headless?
+      # Support HEADLESS= as true, but HEADLESS=false as false
+      ENV.fetch('HEADLESS', false).to_s.downcase != 'false'
+    end
+  end
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# General helper methods for the page
+def page_base_url
+  Config::Pages.page_base_url
+end
+
+# Helpers for the Login Page
+def valid_login_username
+  Config::Pages.valid_login_username
+end
+
+def valid_login_password
+  Config::Pages.valid_login_password
+end


### PR DESCRIPTION
# What

This changeset is based upon but extends prior art brianjbayer/sample-login-watir-cucumber#77 which adds global configuration to the project which is driven by environment variables per 12-factor app principles.

This changeset also adds a new environment variable and configuration for the `BASE_URL` used by the test pages.  Adding this new environment variable is a a "tipping point" refactor for both adding the configuration and the documentation changes in this changeset.

This changeset extends the prior art by adding the Capybara browser environment variables to the global configuration.

# Why
Global configuration encapsulates and abstracts the mechanism of getting the values and is a common practice.

# Change Impact Analysis and Testing
Software changes are directed at the tests which will fail if any of them are incorrect, so CI Checks and running natively will verify and vet for regressions.  Documentation updates however will require execution of the changed commands following the changed documentation in context.

- [x] CI Checks vets URL update and refactor of existing and new environment variables
- [x] Running locally natively URL update and refactor of existing and new environment variables
- [x] Manual inspections of changed documentation in context vets documentation changes
