### PR TITLE
Minor Maintenance for Consistency, Native Testing, Currency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update \
 FROM ruby-base AS builder
 
 # Use the same version of Bundler in the Gemfile.lock
-ARG BUNDLER_VERSION=2.4.21
+ARG BUNDLER_VERSION=2.4.22
 ENV BUNDLER_VERSION=${BUNDLER_VERSION}
 
 # Install base build packages

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,15 +17,17 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     diff-lcs (1.5.0)
-    json (2.6.3)
+    json (2.7.0)
     language_server-protocol (3.17.0.3)
     matrix (0.4.2)
     mini_mime (1.1.5)
-    nokogiri (1.15.4-aarch64-linux)
+    mini_portile2 (2.8.5)
+    nokogiri (1.15.5)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.15.4-arm64-darwin)
+    nokogiri (1.15.5-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-linux)
+    nokogiri (1.15.5-x86_64-linux)
       racc (~> 1.4)
     parallel (1.23.0)
     parallel_tests (4.3.0)
@@ -33,8 +35,8 @@ GEM
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
-    public_suffix (5.0.3)
-    racc (1.7.1)
+    public_suffix (5.0.4)
+    racc (1.7.3)
     rack (3.0.8)
     rack-test (2.1.0)
       rack (>= 1.3)
@@ -57,7 +59,7 @@ GEM
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
     rspec-support (3.12.1)
-    rubocop (1.57.2)
+    rubocop (1.58.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -65,7 +67,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.1, < 2.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.30.0)
@@ -82,7 +84,7 @@ GEM
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
-    selenium-webdriver (4.14.0)
+    selenium-webdriver (4.15.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -99,7 +101,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
-  arm64-darwin-23
+  ruby
   x86_64-linux
 
 DEPENDENCIES
@@ -116,4 +118,4 @@ DEPENDENCIES
   site_prism
 
 BUNDLED WITH
-   2.4.21
+   2.4.22

--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ Before being able to run this project, you must follow the requirements
 in the [PREREQUISITES.md](docs/PREREQUISITES.md)
 
 ## Running
-The easiest way to run the tests is with the docker compose
-framework using the `dockercomposerun` script.
 
 > :apple: The images built for this project are multi-platform
 > images that support both `linux/amd64` (e.g. x86) and
 > `linux/arm64` (i.e. Apple Silicon)
+
+The easiest way to run the tests is with the docker compose
+framework using the `dockercomposerun` script.
 
 This will pull the latest docker image of this project and run
 the tests against a

--- a/script/dockercomposerun
+++ b/script/dockercomposerun
@@ -1,4 +1,5 @@
 #!/bin/sh
+# ----------------------------------------------------------------------
 # This script runs the project docker-compose framework.
 #
 # - The arguments to this script are passed to the browsertests service

--- a/script/mac-test-native-browsers
+++ b/script/mac-test-native-browsers
@@ -1,0 +1,103 @@
+#!/bin/bash
+# ----------------------------------------------------------------------
+# This script is intended for macOS and runs the project tests using
+# all browsers supported on Mac.  This script is for testing during
+# development on this project.
+# ----------------------------------------------------------------------
+
+prompt-to-proceed () {
+  read -p "Do you wish to proceed (Press any key to continue or 'n' to exit)? " response
+  if [[ $response == 'n' ]] || [[ $response == 'N' ]]; then
+    echo " buh-bye"
+    echo ""
+    exit
+  fi
+  echo ""
+}
+
+run_command () {
+  command_to_run="$@"
+  echo "  Executing [${command_to_run}]..."
+  $command_to_run
+  echo "  ... [${command_to_run}] completed"
+  echo ""
+}
+
+set_browser_env () {
+  export BROWSER="$@"
+  echo "BROWSER=${BROWSER-unset}"
+}
+
+set_headless_env () {
+  export HEADLESS="$@"
+  echo "HEADLESS=${HEADLESS-unset}"
+}
+
+load_if_dotenv_file () {
+  if [[ -f .env ]]; then
+    echo "Found .env file, loading it"
+    export $(cat .env | xargs)
+    echo ""
+  fi
+}
+
+### MAIN ###
+# Exit script on any errors
+set -e
+
+echo "Testing the NATIVE sample project - macOS only"
+echo ""
+
+load_if_dotenv_file
+
+echo "Running bundle install - DO NOT COMMIT Gemfile.lock"
+prompt-to-proceed
+run_command bundle install
+echo ""
+
+echo "Testing default"
+run_command bundle exec rake
+
+echo "Testing Chrome"
+set_browser_env chrome
+run_command bundle exec rake
+
+echo "Testing Chrome Headless"
+set_browser_env chrome
+set_headless_env
+run_command bundle exec rake
+set_headless_env false
+
+echo "Testing Edge"
+set_browser_env edge
+run_command bundle exec rake
+
+echo "Testing Edge Headless"
+set_browser_env edge
+set_headless_env foo
+run_command bundle exec rake
+set_headless_env false
+
+echo "Testing Firefox"
+set_browser_env firefox
+run_command bundle exec rake
+
+echo "Testing Firefox Headless"
+set_browser_env firefox
+set_headless_env true
+run_command bundle exec rake
+set_headless_env false
+
+echo "Testing Safari"
+set_browser_env safari
+run_command bundle exec rake
+
+echo "--- ALL TESTS PASSED ---"
+echo ""
+
+echo "Doing git checkout of Gemfile.lock"
+prompt-to-proceed
+run_command git checkout Gemfile.lock
+echo ""
+
+echo "--- FIN ---"


### PR DESCRIPTION
# What 
This maintenance changeset addresses documentation and consistency issues, adds a simple script for running the project tests with supported browsers natively on Mac, and updates `bundler` and gems to latest.

# Why
Consistent documentation, easier development, and dependency currency.

# Change Impact Analysis and Testing

- [x] Inspected changed documentation
- [x] CI Checks pass vetting no regressions and gem updates
- [x] Use new `mac-test-native-browsers` to vet native execution
