### PR TITLE
Update Base Image to Debian Bookworm (12)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #-----------------------------------
 
 #--- Base Image ---
-ARG BASE_IMAGE=ruby:3.2.2-slim-bullseye
+ARG BASE_IMAGE=ruby:3.2.2-slim-bookworm
 FROM ${BASE_IMAGE} AS ruby-base
 
 # Install packages common to builder (dev) and deploy


### PR DESCRIPTION
# What
This changeset updates the base image to latest Debian release Bookworm (version 12).

# Why
Currency

# Change Impact Analysis and Testing
This changeset is limited to the project image.

- [x] CI Checks vet images build and execute with no operational or functional regressions
  - [x] CI Checks vet `amd64` images execute with no operational or functional regressions
- [x] Running `arm64` image on Apple Silicon vets `arm64` images execute with no operational or functional regressions
  - [x] Deploy Image:  `BROWSERTESTS_IMAGE=brianjbayer/sample-login-capybara-rspec_update-base-image-debian-bookworm:cfb0cfb39d487da41f7b5b16563d50e6b7cf387c ./script/dockercomposerun -c`
  - [x] Dev Env Image: `BROWSERTESTS_IMAGE=brianjbayer/sample-login-capybara-rspec_update-base-image-debian-bookworm_dev:cfb0cfb39d487da41f7b5b16563d50e6b7cf387c ./script/dockercomposerun -d`
