### PR TITLE
Add an Invalid Login Test

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,8 @@ AllCops:
   NewCops: enable
 
 # --- Rubocop RSpec Configuration ---
+RSpec/MultipleExpectations:
+  Max: 3
 
 # Allow Capybara "Gherkin" RSpec DSL
 RSpec/Capybara/FeatureMethods:

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gem 'bundler-audit', require: false
 gem 'capybara'
+gem 'debug', '>= 1.0.0'
 gem 'parallel_tests'
 gem 'rake'
 gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,14 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    debug (1.9.0)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     diff-lcs (1.5.0)
+    io-console (0.7.1)
+    irb (1.10.1)
+      rdoc
+      reline (>= 0.3.8)
     json (2.7.0)
     language_server-protocol (3.17.0.3)
     matrix (0.4.2)
@@ -35,6 +42,8 @@ GEM
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
+    psych (5.1.2)
+      stringio
     public_suffix (5.0.4)
     racc (1.7.3)
     rack (3.0.8)
@@ -42,7 +51,11 @@ GEM
       rack (>= 1.3)
     rainbow (3.1.1)
     rake (13.1.0)
+    rdoc (6.6.2)
+      psych (>= 4.0.0)
     regexp_parser (2.8.2)
+    reline (0.4.1)
+      io-console (~> 0.5)
     rexml (3.2.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -93,6 +106,7 @@ GEM
       capybara (~> 3.27)
       site_prism-all_there (~> 2.0)
     site_prism-all_there (2.0.2)
+    stringio (3.1.0)
     thor (1.3.0)
     unicode-display_width (2.5.0)
     websocket (1.2.10)
@@ -107,6 +121,7 @@ PLATFORMS
 DEPENDENCIES
   bundler-audit
   capybara
+  debug (>= 1.0.0)
   parallel_tests
   rake
   rspec

--- a/script/run
+++ b/script/run
@@ -38,7 +38,7 @@ wait_until_ready_if_remote_browser() {
   if [ ! -z "${REMOTE_STATUS}" ];
   then
     # This assumes curl and will not operate correctly without it
-    curl --version || (echo "ERROR: curl command is not found (127)" ; exit 127)
+    curl --version > /dev/null 2>&1 || (echo "ERROR: curl command is not found (127)" ; exit 127)
 
     COUNTER=0
     echo "Waiting for remote browser at [${REMOTE_STATUS}] to become available"

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -17,4 +17,11 @@ feature 'User logs in' do
     # Allow at least 5 seconds for page to load
     expect(secure_area_page).to be_displayed(5)
   end
+
+  scenario 'with invalid password and an error is displayed' do
+    login_page.login_with_invalid_password
+    expect(login_page.current_url).to eq(login_page.url)
+    expect(login_page).to have_login_error
+    expect(login_page.login_error.text).to include('Your password is invalid!')
+  end
 end

--- a/spec/features/site_prism/login_page.rb
+++ b/spec/features/site_prism/login_page.rb
@@ -7,9 +7,17 @@ class LoginPage < SitePrism::Page
   element :password_input, 'input[id="password"]'
   element :submit_button, 'button[type="submit"]'
 
+  element :login_error, '#flash'
+
   def login_with_valid_credentials
     username_input.set valid_login_username
     password_input.set valid_login_password
+    submit_button.click
+  end
+
+  def login_with_invalid_password
+    username_input.set valid_login_username
+    password_input.set 'NotAValidPassword'
     submit_button.click
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'capybara'
 require 'capybara/rspec'
+require 'debug'
 require 'selenium-webdriver'
 require 'site_prism'
 


### PR DESCRIPTION
# What
This changeset...

1. Adds an invalid (password) login test
2. Mutes the output of the `curl` present check
3. Adds the [`debug`](https://github.com/ruby/debug) gem

# Why
* The invalid login test demonstrates how to verify an error response and provides a logical counterpoint to a valid login
* The extraneous and verbose output during the `curl` check was distracting
* The addition of the `debug` gem makes debugging during development easier

# Change Impact Analysis and Testing

- [x] CI Checks vets newly added test and no regressions to existing behavior as well as code quality and standards
- [x] Native execution (Apple Silicon) vets newly added test and no regressions to existing behavior
- [x] Inspection of CI Checks and local run of `dockercomposerun` vets `curl` check output is silenced
- [x] Usage of `debug` gem natively vets its correct addition
