### PR TITLE
Suspend MS Edge and Apple Safari Browser Support

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -69,7 +69,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [chrome, firefox, edge]
+        # MS Edge is currently not supported per brianjbayer/sample-login-capybara-rspec#97
+        # browser: [chrome, firefox, edge]
+        browser: [chrome, firefox]
     runs-on: ubuntu-latest
     env:
       UNVETTED_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
@@ -104,7 +106,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [chrome, firefox, edge]
+        # MS Edge is currently not supported per brianjbayer/sample-login-capybara-rspec#97
+        # browser: [chrome, firefox, edge]
+        browser: [chrome, firefox]
     runs-on: ubuntu-latest
     env:
       DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # sample-login-capybara-rspec
 
 ## Overview
+
+> :unamused: Currently Microsoft Edge Browser is not supported
+> in this project per brianjbayer/sample-login-capybara-rspec#97
+
 This is an example of End-To-End (E2E) Tests/Acceptance Test
 Driven Development (ATDD) using
 [Capybara](https://github.com/teamcapybara/capybara),

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 ## Overview
 
-> :unamused: Currently Microsoft Edge Browser is not supported
-> in this project per brianjbayer/sample-login-capybara-rspec#97
+> :unamused: Currently neither Microsoft Edge nor Apple Safari
+> browsers are supported in this project per
+> brianjbayer/sample-login-capybara-rspec#97
 
 This is an example of End-To-End (E2E) Tests/Acceptance Test
 Driven Development (ATDD) using

--- a/script/dockercomposerun
+++ b/script/dockercomposerun
@@ -71,7 +71,7 @@ if [ -z ${noselenium} ]; then
   echo "...Adding Selenium Browser to Environment"
   docker_compose_command="${docker_compose_command} -f docker-compose.selenium.yml "
 
-  if [[ `uname -m` == "arm64" ]]; then
+  if [ `uname -m` = "arm64" ]; then
     echo "...Apple Silicon Detected adding Seleniarm Browser Override to Environment"
     docker_compose_command="${docker_compose_command} -f docker-compose.seleniarm.yml "
   fi

--- a/script/mac-test-native-browsers
+++ b/script/mac-test-native-browsers
@@ -88,9 +88,10 @@ set_headless_env true
 run_command bundle exec rake
 set_headless_env false
 
-echo "Testing Safari"
-set_browser_env safari
-run_command bundle exec rake
+# Apple Safari is currently not supported per brianjbayer/sample-login-capybara-rspec#97
+# echo "Testing Safari"
+# set_browser_env safari
+# run_command bundle exec rake
 
 echo "--- ALL TESTS PASSED ---"
 echo ""


### PR DESCRIPTION
# What
This changeset suspends official project support for Microsoft Edge and Apple Safari browsers.  It is unfortunate that these two companies are more interested in selling a product instead of making a product worth selling.

Things may change in the future, so I am commenting out the support instead of fully removing it.  It may also be of use as a potential reference.

In addition, this changeset addresses a bug where double brackets (`[[ ... ]]`) were used instead of single brackets (`[ ... ]`) in the `dockercomposerun` script which is `sh`ell and not `bash`.

# Why
Support for MS Edge is being suspended due to...
1. Its user-experience disruptive **_Personalize your web experience_** popup which would require browser-specific customization
2. This [Selenium issue](https://github.com/SeleniumHQ/docker-selenium/issues/2052) which seems to be triggered in the CI Run
3. Unable to run the `selenium-standalone-edge` browser image on Apple Silicon

I added MS Edge support as a nice to have but as seems to be common with Microsoft, we can not have nice things.

Support for Apple Safari is being suspended due to the following error which is a `safaridriver` issue...
```
Selenium::WebDriver::Error::WebDriverError:
  unable to connect to /usr/bin/safaridriver 127.0.0.1:7050
```

# Change Impact Analysis and Testing

- [x] CI Checks vet no regressions
- [x] Inspection of CI Checks output verifies CI is not using MS Edge and fix of single brackets
- [x] Successful execution and inspection of output of native (Apple Silicon) run of `dockercomposerun` ensures fix of single brackets results in no regressions
- [x] Local (Apple Silicon) execution using `mac-test-native-browsers` script vets supported browsers and suspension of Safari support
- [x] Manual inspection of rendered README on this branch verifies documentation update
