### PR TITLE
Restore Apple Safari Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 ## Overview
 
-> :unamused: Currently neither Microsoft Edge nor Apple Safari
-> browsers are supported in this project per
-> brianjbayer/sample-login-capybara-rspec#97
+> :unamused: Currently Microsoft Edge Browser is not supported
+> in this project per brianjbayer/sample-login-capybara-rspec#97
 
 This is an example of End-To-End (E2E) Tests/Acceptance Test
 Driven Development (ATDD) using

--- a/script/mac-test-native-browsers
+++ b/script/mac-test-native-browsers
@@ -88,10 +88,9 @@ set_headless_env true
 run_command bundle exec rake
 set_headless_env false
 
-# Apple Safari is currently not supported per brianjbayer/sample-login-capybara-rspec#97
-# echo "Testing Safari"
-# set_browser_env safari
-# run_command bundle exec rake
+echo "Testing Safari"
+set_browser_env safari
+run_command bundle exec rake
 
 echo "--- ALL TESTS PASSED ---"
 echo ""


### PR DESCRIPTION
# What
This changeset restores project support for native Apple Safari browser. 

# Why
:shrug: Although support for the (native) Apple Safari browser was suspended by brianjbayer/sample-login-capybara-rspec#97 due to Selenium errors, I was able to get Safari working again by a machine reboot and running...
```bash
sudo /usr/bin/safaridriver --enable
```

I am not sure the `sudo` is necessary but it does enable `safaridriver` at root admin level.

# Change Impact Analysis and Testing
Changes are limited to the README and the `mac-test-native-browsers` script.

- [x] Vetted native Safari works as well as the changes in `mac-test-native-browsers` by running that script successfully
- [x] Manually inspected updated README on this branch
- [x] CI Checks vet no regressions 
