### PR TITLE
Update Invalid Login Test To Use SitePrism displayed? To Be More Resilient

### DIFF
--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -20,7 +20,7 @@ feature 'User logs in' do
 
   scenario 'with invalid password and an error is displayed' do
     login_page.login_with_invalid_password
-    expect(login_page.current_url).to eq(login_page.url)
+    expect(login_page).to be_displayed
     expect(login_page).to have_login_error
     expect(login_page.login_error.text).to include('Your password is invalid!')
   end


### PR DESCRIPTION
# What
Update the invalid login test to use the SItePrism `be_displayed` matcher instead of previous `expect(login_page.current_url).to eq(login_page.url)`.

# Why
The `current_url` expectation was failing on Safari as it redirected to `/authenticate` first.  the SItePrism `be_displayed` matcher matches against the page description including url and uses the `Capybara.default_max_wait_time` making the test more resilient.

# Change Impact Analysis and Testing
This change is limited to the invalid login test.   This failure only manifested on Safari natively.

- [x] All tests now pass consistently natively
- [x] CI Checks vets no regressions
