### PR TITLE
Use Cross-Compilation in Multi Platform Builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #--- Base Image ---
 # Ruby version must mttch that in Gemfile.lock
 ARG ARG BASE_IMAGE=ruby:3.2.4-slim-bookworm
-FROM ${BASE_IMAGE} AS ruby-base
+FROM --platform=$BUILDPLATFORM ${BASE_IMAGE} AS ruby-base
 
 # Install packages common to builder (dev) and deploy
 ARG BASE_PACKAGES='curl'


### PR DESCRIPTION
# What & Why
This is a one-line change to the Dockerfile to use cross-compiltion to decrease the elapsed time of multi-platform builds (especially in CI) as reommended in the [Faster Multi-Platform Builds: Dockerfile Cross-Compilation Guide](https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide) by Docker.


# Change Impact Analysis and Testing
This change is based upon Prior Art and demonstrated ability of `buildx`.

- [x] Inspection of image build in CI Checks verifies cross-compilation
  - [x] Improvement in multi-platform image building
    - [x] Dev Image - [Current: ](https://github.com/brianjbayer/sample-login-capybara-rspec/actions/runs/9424700356/job/25965373169) 1m 11s  vs [Previous:](https://github.com/brianjbayer/sample-login-capybara-rspec/actions/runs/9424700356/job/25965373169) 11m 57s
    - [x] Deploy Image - [Current:](https://github.com/brianjbayer/sample-login-capybara-rspec/actions/runs/9424700356/job/25965373000) 1m 2s vs   [Previous:](https://github.com/brianjbayer/sample-login-capybara-rspec/actions/runs/9343455949/job/25713086130) 10m 57s
- [x] CI Checks vet there are no regressions in `amd64`
- [x] Local (Apple Silicon) image operations vets there are no regressions in `arm64`...
  - [x] Dev Image - `BROWSERTESTS_IMAGE=brianjbayer/sample-login-capybara-rspec_cross-compile-in-multiplatform-builds_dev:e3273d5043192882e01c0e5d35029b45175adf0f ./script/dockercomposerun ./script/run tests` 
  - [x] Deploy Image - `BROWSERTESTS_IMAGE=brianjbayer/sample-login-capybara-rspec_cross-compile-in-multiplatform-builds:e3273d5043192882e01c0e5d35029b45175adf0f ./script/dockercomposerun`
- [x] Local (Apple Silicon) image build and operation vets there are no regressions in `arm64`
  - [x] Dev Image
  - [x] Deploy Image
