### PR TITLE
Revert False Cross-Compilation in Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #--- Base Image ---
 # Ruby version must mttch that in Gemfile.lock
 ARG ARG BASE_IMAGE=ruby:3.2.4-slim-bookworm
-FROM --platform=$BUILDPLATFORM ${BASE_IMAGE} AS ruby-base
+FROM ${BASE_IMAGE} AS ruby-base
 
 # Install packages common to builder (dev) and deploy
 ARG BASE_PACKAGES='curl'


### PR DESCRIPTION
# What
This one-line change reverts brianjbayer/sample-login-capybara-rspec#111 by removing `--platform=$BUILDPLATFORM` from the `Dockerfile` base image directive.

# Why
The `--platform=$BUILDPLATFORM` causes a false build of the `linux/arm64` platform image using the `BUILDPLATFORM` which is `linux/amd64` (ubuntu runner) .  This reverts that regression.  Note that most operations do still work but only by chance.

# Change Impact Analysis and Testing
This simply takes things back to before brianjbayer/sample-login-capybara-rspec#111

- [x] Verify there is no difference between this comimit and (merge) commit prior to brianjbayer/random_thoughts_api#83 with `gd 3f31779810f59e35bf580df3f5a119bd911e1cc6..HEAD` returning empty
