### PR TITLE
Rebuild images with proper names

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ These tests show how to use Capybara-RSpec to verify...
 It also demonstrates the basic features of the
 Capybara-RSpec framework and how they can be extended.
 
+---
+
 ## Run Locally or in Containers
 This project can be run...
 * Locally containerized in 2 separate Docker containers:


### PR DESCRIPTION
# What & Why
This mostly no-op change forces rebuild of project images so that they have correct name.

