### PR TITLE
Deprecate the `seleniarm/standalone-chromium` image for `selenium/standalone-chromium`

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ You can use either a VNC client or a web browser to view the tests.
 For more information, see the Selenium Standalone Image
 [VNC documentation](https://github.com/SeleniumHQ/docker-selenium#debugging)
 
-### Running Using the Default Chrome Standalone Container
+### Running Using the Default Chromium Standalone Container
 By default, the `dockercomposerun` script runs using the
-latest Selenium Standalone Chrome container.
+latest Selenium Standalone Chromium container.
 
 1. Ensure Docker is running
 2. From the project root directory, run the `dockercomposerun`
@@ -96,10 +96,6 @@ latest Selenium Standalone Chrome container.
    ```
    ./script/dockercomposerun
    ```
-
-> :apple: Apple Silicon Macs will actually run against the
-> [Seleniarm Standalone](https://github.com/seleniumhq-community/docker-seleniarm)
-> container
 
 ### Running Using Other Selenium Standalone Containers
 You can also run the tests using other Selenium Standalone
@@ -145,8 +141,6 @@ These tests use the...
 [SitePrism on GitHub](https://github.com/natritmeyer/site_prism)
 * Selenium Standalone Containers: [Selenium HQ on GitHub](https://github.com/SeleniumHQ/docker-selenium),
   [Selenium on Docker Hub](https://hub.docker.com/u/selenium)
-* Seleniarm Standalone Containers [Seleniarm HQ on GitHub](https://github.com/seleniumhq-community/docker-seleniarm),
-  [Seleniarm on Docker Hub](https://hub.docker.com/u/seleniarm)
 * Rubocop style enforcer and linter: [Rubocop docs](https://rubocop.org/),
   [Rubocop on GitHub](https://github.com/rubocop/rubocop)
 * bundler-audit dependency static security scanner: [bundler-audit on GitHub](https://github.com/rubysec/bundler-audit)

--- a/docker-compose.seleniarm.yml
+++ b/docker-compose.seleniarm.yml
@@ -1,3 +1,0 @@
-services:
-  seleniumbrowser:
-    image: ${SELENIUM_IMAGE:-seleniarm/standalone-chromium:latest}

--- a/docker-compose.selenium.yml
+++ b/docker-compose.selenium.yml
@@ -8,8 +8,9 @@ services:
     depends_on:
       - seleniumbrowser
 
-  seleniumbrowser :
-    image: ${SELENIUM_IMAGE:-selenium/standalone-chrome:latest}
+  seleniumbrowser:
+    # The selenium/standalone-chromium image is multiplatform (arm64)
+    image: ${SELENIUM_IMAGE:-selenium/standalone-chromium:latest}
     container_name: ${SELENIUM_HOSTNAME:-seleniumbrowser}
     shm_size: 4gb
     volumes:

--- a/docs/RUNNING_WITH_OTHER_CONTAINERS.md
+++ b/docs/RUNNING_WITH_OTHER_CONTAINERS.md
@@ -12,16 +12,10 @@ in the [PREREQUISITES.md](PREREQUISITES.md)
 2. From the project root directory, run the `dockercomposerun`
    script setting the `BROWSER` and `SELENIUM_IMAGE`
    environment variables to specify Firefox...
-
-   **For Intel/x86/amd64 run...**
    ```
    BROWSER=firefox SELENIUM_IMAGE=selenium/standalone-firefox ./script/dockercomposerun
    ```
 
-   **:apple: For Apple Silicon/arm64 run...**
-   ```
-   BROWSER=firefox SELENIUM_IMAGE=seleniarm/standalone-firefox ./script/dockercomposerun
-   ```
 
 ### To Run Using the Edge Standalone Container
 1. Ensure Docker is running

--- a/script/dockercomposerun
+++ b/script/dockercomposerun
@@ -51,10 +51,7 @@ shift $((OPTIND-1))
 echo "DOCKER VERSION: [`docker --version`]"
 docker_compose_command='docker compose -f docker-compose.yml '
 
-if [ -z ${browsertests_only} ] ; then
-  docker_compose_command="${docker_compose_command} -f docker-compose.selenium.yml "
-  [ `uname -m` == "arm64" ] && docker_compose_command="${docker_compose_command} -f docker-compose.seleniarm.yml "
-fi
+[ -z ${browsertests_only} ] && docker_compose_command="${docker_compose_command} -f docker-compose.selenium.yml "
 
 [ ! -z ${devenv} ] && docker_compose_command="${docker_compose_command} -f docker-compose.dev.yml "
 [ ! -z ${ci} ] && docker_compose_command="${docker_compose_command} -f docker-compose.ci.yml "


### PR DESCRIPTION
# What
The forked `seleniarm/standalone-chromium` image has been deprecated and merged into the main `selenium` project so now the `selenium/standalone-chromium` image is multiplatform (supports `arm64`).  This changeset switches to the `selenium/standalone-chromium` image and deprecates `seleniarm/standalone-chromium` in the docker compose framework.

# Why
This ensures that the chrome browser used in the tests remains current.

# Change Impact Analysis and Testing

- [x] Successful PR Checks verifies changed behavior and no regressions
- [x] Local execution on Apple Silicon verifies `arm64`
- [x] Inspection of rendered changed documentation on branch verifies correctness
