### PR TITLE
Refactor Default Rake and Parallel RSpec Tasks

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -76,7 +76,7 @@ jobs:
     uses: ./.github/workflows/run-e2e-tests.yml
     with:
       e2e_tests_image: ${{ needs.image-names.outputs.dev_image }}
-      e2e_tests_command: "./script/dockercomposerun -d bash -c './wait_on_endpoint && bundle exec rspec'"
+      e2e_tests_command: "./script/dockercomposerun -d bash -c './wait_on_endpoint && ./script/run -p tests'"
     secrets:
       login_username: ${{ secrets.LOGIN_USERNAME }}
       login_password: ${{ secrets.LOGIN_PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,4 +81,4 @@ COPY --chown=deployer . /app/
 
 # Run the tests but allow override
 # Expects the wait_on_endpoint script environment variables to be set
-CMD ["bash", "-c", "./wait_on_endpoint && bundle exec rspec"]
+CMD ["bash", "-c", "./wait_on_endpoint && ./script/run -p tests"]

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bundler/audit/task'
+require 'parallel_tests/tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 
@@ -15,18 +16,19 @@ task :checks do
   Rake::Task['bundle:audit'].invoke
 end
 
-# DEFAULT: Run specs in parallel
-# TODO is this still necessary
-desc 'run specs in parallel unless safari'
-task :spec do
-  if ENV['BROWSER'] == 'safari'
-    warn 'rake: running specs SEQUENTIALLY for safari'
-    RSpec::Core::RakeTask.new(:spec)
-
-  else
-    warn 'rake: running specs in PARALLEL'
-    ruby '-S parallel_rspec spec'
+# RSpec parallel task is the default
+namespace :rspec do
+  desc 'Run RSpec in parallel using parallel_tests'
+  task :parallel do
+    if ENV['BROWSER'] == 'safari'
+      warn 'rake: running specs SEQUENTIALLY for safari'
+      RSpec::Core::RakeTask.new(:spec)
+      Rake::Task['spec'].invoke
+    else
+      Rake::Task['parallel:spec'].invoke
+    end
   end
 end
 
-task default: :spec
+# Set the Default to running in parallel
+task default: 'rspec:parallel'

--- a/docker-compose.selenium.yml
+++ b/docker-compose.selenium.yml
@@ -20,7 +20,7 @@ services:
       - "5900:5900"
       - "7900:7900"
     environment:
-      - SE_NODE_OVERRIDE_MAX_SESSIONS=true
+      # The number of browser sessions should correspond to parallelism
       - SE_NODE_MAX_SESSIONS=2
     healthcheck:
       test: ["CMD-SHELL", '/opt/bin/check-grid.sh --host 0.0.0.0 --port 4444']

--- a/script/run
+++ b/script/run
@@ -1,24 +1,57 @@
 #!/bin/sh
-# -----------------------------------------------
-# Project run script to run
-#   - lint
-#   - secscan
-#   - tests
-#   - or it runs all arguments
-# -----------------------------------------------
+
+# --- Project Commands ---
+# Running tests
+tests='rspec'
+parallel_tests='parallel_rspec'
+
+# Code standards
+lint='rubocop'
+secscan='bundle-audit check --update'
+
+be='bundle exec'
+lint_cmd="${be} ${lint}"
+secscan_cmd="${be} ${secscan}"
+tests_cmd="${be} ${tests}"
+parallel_tests_cmd="${be} ${parallel_tests}"
+
+usage() {
+  cat << USAGE
+Usage: $0 [-hp] [COMMAND] [ARG...]
+This is the project "run" script, executing common application tasks.
+
+If the COMMAND is not recognized, it runs all arguments as a command:
+
+COMMANDS:
+  lint:     Run the linter [$lint_cmd]
+
+  secscan:  Run the security scanner [$secscan_cmd]
+
+  tests:    Run the tests [$tests_cmd]
+            (in parallel if -p specified) [$parallel_tests_cmd]
+
+  [COMMAND] [ARG...]: Run any other command with arguments
+
+OPTIONS:
+  -h: Show this help message
+  -p: if supported by the COMMAND, runs in parallel
+USAGE
+}
 
 # --- Functions ---
+err_exit() {
+  err_code=$1
+  err_msg="$2"
+  echo "${err_msg} (${err_code})" 1>&2
+  exit $err_code
+}
+
 run_and_exit_return_code () {
   # Exit script on any errors
   set -e
 
-  # Set to all positional parameters each expanding
-  # to a separate word
   command_to_run="$@"
-  if [ -z "$command_to_run" ]; then
-    echo "ERROR: Function requires a command argument (86)"
-    exit 86
-  fi
+  [ -z "$command_to_run" ] && err_exit 1 "Missing argument"
 
   # Run the command and preserve exit code
   echo "RUNNING [${command_to_run} ]..."
@@ -34,39 +67,47 @@ run_and_exit_return_code () {
   exit $run_return_code
 }
 
-# ------------
 # --- MAIN ---
-# ------------
 # Exit script on any errors
 set -e
 
-# set run command if recognized action
-action="${1}"
-case "$action" in
-  "lint")
-    shift
-    run_command="bundle exec rubocop $@"
-  ;;
+while getopts ":hp" options; do
+  case "${options}" in
+    p)
+      parallel=1
+      ;;
+    h)
+      usage ; exit
+      ;;
+    \?)
+      usage
+      err_exit 1 "Invalid Option: -$OPTARG"
+      ;;
+  esac
+done
+shift $((OPTIND-1))
 
-  "secscan")
-    shift
-    run_command="bundle exec bundle-audit check --update $@"
-  ;;
+# Set command to run if recognized COMMAND
+command="${1}"
 
-  "tests")
-    shift
-    run_command="bundle exec rspec $@"
-  ;;
-esac
+[ "$command" = 'lint' ] && run_command="${lint_cmd}"
 
-if [ -z "$run_command" ]; then
-  # No recognized actions so run all the arguments as the command"
-  run_command="$@"
+[ "$command" = 'secscan' ] && run_command="${secscan_cmd}"
+
+if [ "$command" = 'tests' ] ; then
+  run_command="${tests_cmd}"
+  [ -n "${parallel}" ] && run_command="${parallel_tests_cmd}"
+fi
+
+if [ -n "$run_command" ]; then
+  shift
+  run_command="${run_command} $@"
+  echo "RUNNING COMMAND [${action}]"
 else
-  echo "RUNNING Action [${action}]"
+# No recognized actions so run all the arguments as the command"
+  run_command="$@"
 fi
 
 # Run the command and exit passing any arguments
 run_and_exit_return_code "$run_command"
-echo "ERROR: should have exited!!! (99)"
-exit 99
+err_exit 99 "LOGIC ERROR"


### PR DESCRIPTION
# What
This infrastructure change set refactors the `Rakefile`  and `run` script to follow current standards.

# Why
Uses standard appropriate rake tasks.  Provide usage and parallel (test) execution and simplify `run` script.

# Change Impact Analysis and Testing

- [x] Successful PR Checks verifies core `run` script functionality and no regressions
- [x] Local execution of `./script run -h` and inspection of output verifies usage
- [x] Local execution of `./script run -z` and inspection of output verifies invalid option logic
- [x] Local execution of ``./script run tests` verifies operating tests sequentially
- [x] Local execution of `bundle exec rake` and inspection of output verifies...
  - [x] Tests run in parallel in non-Safari supported browsers
  - [x] Test run sequentially in Safari
