### PR TITLE
Add Support for Specifying Browsers in run-e2e-tests workflow (Restore Running Edge)

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -63,6 +63,7 @@ jobs:
     with:
       e2e_tests_image: ${{ needs.image-names.outputs.unvetted_image }}
       e2e_tests_command: "./script/dockercomposerun -c"
+      browsers: "['chrome', 'firefox', 'edge']"
     secrets:
       login_username: ${{ secrets.LOGIN_USERNAME }}
       login_password: ${{ secrets.LOGIN_PASSWORD }}
@@ -77,6 +78,7 @@ jobs:
     with:
       e2e_tests_image: ${{ needs.image-names.outputs.dev_image }}
       e2e_tests_command: "./script/dockercomposerun -d bash -c './wait_on_endpoint && ./script/run -p tests'"
+      browsers: "['chrome', 'firefox', 'edge']"
     secrets:
       login_username: ${{ secrets.LOGIN_USERNAME }}
       login_password: ${{ secrets.LOGIN_PASSWORD }}

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -13,9 +13,14 @@ on:
         required: true
         type: string
       e2e_tests_command:
-        description: "The End-to-End tests image to run"
+        description: "The End-to-End tests command to run"
         required: true
         type: string
+      browsers:
+        description: "The browsers to run tests against (Default: ['chrome', 'firefox'])"
+        required: false
+        type: string
+        default: "['chrome', 'firefox']"
 
     secrets:
       login_username:
@@ -32,9 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # MS Edge is currently not supported per brianjbayer/sample-login-capybara-rspec#97
-        browser: [chrome, firefox, edge]
-        # browser: [chrome, firefox]
+        browser: ${{ fromJSON(inputs.browsers) }}
     env:
       BROWSERTESTS_IMAGE: ${{ inputs.e2e_tests_image }}
       BROWSER: ${{ matrix.browser }}

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -33,8 +33,8 @@ jobs:
       fail-fast: false
       matrix:
         # MS Edge is currently not supported per brianjbayer/sample-login-capybara-rspec#97
-        # browser: [chrome, firefox, edge]
-        browser: [chrome, firefox]
+        browser: [chrome, firefox, edge]
+        # browser: [chrome, firefox]
     env:
       BROWSERTESTS_IMAGE: ${{ inputs.e2e_tests_image }}
       BROWSER: ${{ matrix.browser }}


### PR DESCRIPTION
# What
This CI-only changeset adds the optional `browsers` input to the shared workflow `run-e2e-tests`.  This `string` input allows a list of browsers to be specified as a JSON array of strings, for example...
```yaml
browsers: "['chrome', 'firefox', 'edge']"
```

This new inputs is then used in the PR workflow to restore running (`linux/amd64`) the Edge browser in CI.


# Change Impact Analysis and Testing

- [x] Successful PR Checks and their inspection verifies these changes and that there are no regressions
