### PR TITLE
Update To Latest Bundler (4.0.6) and Gems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE=ruby:4.0.1-slim-trixie
 FROM ${BASE_IMAGE} AS ruby-base
 
 # Use the same version of Bundler in the Gemfile.lock
-ARG BUNDLER_VERSION=4.0.5
+ARG BUNDLER_VERSION=4.0.6
 ENV BUNDLER_VERSION=${BUNDLER_VERSION}
 
 #--- Builder Stage ---
@@ -12,6 +12,8 @@ FROM ruby-base AS builder
 
 # Install base build packages
 ARG BASE_BUILD_PACKAGES='build-essential libyaml-dev'
+
+ARG BUNDLER_PATH=/usr/local/bundle
 
 # Assumes debian based
 RUN apt-get update \
@@ -21,7 +23,9 @@ RUN apt-get update \
   # Update gem command to latest
   && gem update --system \
   # Install bundler
-  && gem install bundler:${BUNDLER_VERSION}
+  && gem install bundler:${BUNDLER_VERSION} \
+  # Configure bundler to use isolated gem path
+  && bundle config set --local path ${BUNDLER_PATH}
 
 # Install the Ruby dependencies (defined in the Gemfile/Gemfile.lock)
 WORKDIR /app

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,11 +24,12 @@ GEM
     diff-lcs (1.6.2)
     erb (6.0.1)
     io-console (0.8.2)
-    irb (1.16.0)
+    irb (1.17.0)
       pp (>= 0.6.0)
+      prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.18.0)
+    json (2.18.1)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -43,9 +44,9 @@ GEM
     nokogiri (1.19.1-x86_64-linux-gnu)
       racc (~> 1.4)
     parallel (1.27.0)
-    parallel_tests (5.5.0)
+    parallel_tests (5.6.0)
       parallel
-    parser (3.3.10.1)
+    parser (3.3.10.2)
       ast (~> 2.4.1)
       racc
     pp (0.6.3)
@@ -62,7 +63,7 @@ GEM
       rack (>= 1.3)
     rainbow (3.1.1)
     rake (13.3.1)
-    rdoc (7.1.0)
+    rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
       tsort
@@ -85,7 +86,7 @@ GEM
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
     rspec-support (3.13.7)
-    rubocop (1.84.0)
+    rubocop (1.84.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -155,4 +156,4 @@ RUBY VERSION
   ruby 4.0.1
 
 BUNDLED WITH
-  4.0.5
+  4.0.6


### PR DESCRIPTION
# What & Why

This maintenance changeset updates the project to latest bundler (`4.0.6`) and gems, resolving new rubocop violations.  This maintains currency making future updates less risk.

It also updates the `Dockerfile` to configure bundler to use isolated gem path to avoid dependency version conflicts during `bundle` operations resulting in warnings like these...

```text
root@f1e33713ec17:/app# bundle update --all
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
/usr/local/bundle/gems/rdoc-7.2.0/lib/rdoc/version.rb:8: warning: already initialized constant RDoc::VERSION
/usr/local/lib/ruby/gems/4.0.0/gems/rdoc-7.0.3/lib/rdoc/version.rb:8: warning: previous definition of VERSION was here
/usr/local/bundle/gems/rdoc-7.2.0/lib/rdoc.rb:68: warning: already initialized constant RDoc::VISIBILITIES
/usr/local/lib/ruby/gems/4.0.0/gems/rdoc-7.0.3/lib/rdoc.rb:68: warning: previous definition of VISIBILITIES was here
...
```

# Change Impact Analysis and Testing

- [x] Successful PR Checks verify no regressions
- [x] Performing bundle operation in container results in no warnings